### PR TITLE
Arduboy core class (that other classes build upon)

### DIFF
--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -1,169 +1,18 @@
 #include "Arduboy.h"
 #include "glcdfont.c"
 
-const uint8_t PROGMEM lcdBootProgram[] = {
-  0xAE,  // Display Off
-  0XD5,  // Set Display Clock Divisor v
-  0xF0,  //   0x80 is default
-  0xA8,  // Set Multiplex Ratio v
-  0x3F,
-  0xD3,  // Set Display Offset v
-  0x00,
-  0x40,  // Set Start Line (0)
-  0x8D,  // Charge Pump Setting v
-  0x14,  //   Enable
-  // running this next pair twice?
-  0x20,  // Set Memory Mode v
-  0x00,  //   Horizontal Addressing
-  0xA1,  // Set Segment Re-map (A0) | (b0001)
-  0xC8,  // Set COM Output Scan Direction
-  0xDA,  // Set COM Pins v
-  0x12,
-  0x81,  // Set Contrast v
-  0xCF,
-  0xD9,  // Set Precharge
-  0xF1,
-  0xDB,  // Set VCom Detect
-  0x40,
-  0xA4,  // Entire Display ON
-  0xA6,  // Set normal/inverse display
-  0xAF,  // Display On
-
-  0x20,     // set display mode
-  0x00,     // horizontal addressing mode
-
-  0x21,     // set col address
-  0x00,
-  COLUMN_ADDRESS_END,
-
-  0x22, // set page address
-  0x00,
-  PAGE_ADDRESS_END
-};
 
 Arduboy::Arduboy() { }
 
 void Arduboy::start()
 {
-  #if F_CPU == 8000000L
-  slowCPU();
-  #endif
-
-  SPI.begin();
-  bootPins();
-  bootLCD();
-
-  #ifdef SAFE_MODE
-  if (pressed(LEFT_BUTTON+UP_BUTTON))
-    safeMode();
-  #endif
-
-  audio.setup();
-  saveMuchPower();
-}
-
-#if F_CPU == 8000000L
-// if we're compiling for 8Mhz we need to slow the CPU down because the
-// hardware clock on the Arduboy is 16MHz
-void Arduboy::slowCPU()
-{
-  uint8_t oldSREG = SREG;
-  cli();                // suspend interrupts
-  CLKPR = _BV(CLKPCE);  // allow reprogramming clock
-  CLKPR = 1;            // set clock divisor to 2 (0b0001)
-  SREG = oldSREG;       // restore interrupts
-}
-#endif
-
-void Arduboy::bootPins()
-{
-  // OLED SPI
-  pinMode(DC, OUTPUT);
-  pinMode(CS, OUTPUT);
-  pinMode(RST, OUTPUT);
-  digitalWrite(RST, HIGH);
-  delay(1);           // VDD (3.3V) goes high at start, lets just chill for a ms
-  digitalWrite(RST, LOW);   // bring reset low
-  delay(10);          // wait 10ms
-  digitalWrite(RST, HIGH);  // bring out of reset
-
-  // Buttons
-  pinMode(PIN_LEFT_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_RIGHT_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_UP_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_DOWN_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_A_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_B_BUTTON, INPUT_PULLUP);
+  boot(); // required
 
   // Audio
   tunes.initChannel(PIN_SPEAKER_1);
   tunes.initChannel(PIN_SPEAKER_2);
+  audio.setup();
 }
-
-void Arduboy::bootLCD()
-{
-  // setup the ports we need to talk to the OLED
-  csport = portOutputRegister(digitalPinToPort(CS));
-  cspinmask = digitalPinToBitMask(CS);
-  dcport = portOutputRegister(digitalPinToPort(DC));
-  dcpinmask = digitalPinToBitMask(DC);
-
-  LCDCommandMode();
-  for (int8_t i=0; i < sizeof(lcdBootProgram); i++) {
-    SPI.transfer(pgm_read_byte(lcdBootProgram + i));
-  }
-  LCDDataMode();
-}
-
-// Safe Mode is engaged by holding down both the LEFT button and UP button
-// when plugging the device into USB.  It puts your device into a tight
-// loop and allows it to be reprogrammed even if you have uploaded a very
-// broken sketch that interferes with the normal USB triggered auto-reboot
-// functionality of the device.
-void Arduboy::safeMode()
-{
-  display(); // too avoid random gibberish
-  while (true) {
-    asm volatile("nop \n");
-  }
-}
-
-void Arduboy::LCDDataMode()
-{
-  *dcport |= dcpinmask;
-  *csport &= ~cspinmask;
-}
-
-void Arduboy::LCDCommandMode()
-{
-  *csport |= cspinmask; // why are we doing this twice?
-  *csport |= cspinmask;
-  *dcport &= ~dcpinmask;
-  *csport &= ~cspinmask;
-}
-
-
-/* Power Management */
-
-void Arduboy::idle()
-{
-  set_sleep_mode(SLEEP_MODE_IDLE);
-  sleep_mode();
-}
-
-void Arduboy::saveMuchPower()
-{
-  power_adc_disable();
-  power_usart0_disable();
-  power_twi_disable();
-  // timer 0 is for millis()
-  // timers 1 and 3 are for music and sounds
-  power_timer2_disable();
-  power_usart1_disable();
-  // we need USB, for now (to allow triggered reboots to reprogram)
-  // power_usb_disable()
-}
-
 
 /* Frame management */
 
@@ -245,11 +94,6 @@ uint16_t Arduboy::rawADC(byte adc_bits)
 
 
 /* Graphics */
-
-void Arduboy::blank()
-{
-  for (int a = 0; a < (HEIGHT*WIDTH)/8; a++) SPI.transfer(0x00);
-}
 
 void Arduboy::clearDisplay()
 {
@@ -800,32 +644,13 @@ size_t Arduboy::write(uint8_t c)
 
 void Arduboy::display()
 {
-  this->drawScreen(sBuffer);
-}
-
-void Arduboy::drawScreen(const unsigned char *image)
-{
-  for (int a = 0; a < (HEIGHT*WIDTH)/8; a++)
-  {
-    SPI.transfer(pgm_read_byte(image + a));
-  }
-}
-
-void Arduboy::drawScreen(unsigned char image[])
-{
-  for (int a = 0; a < (HEIGHT*WIDTH)/8; a++)
-  {
-    SPI.transfer(image[a]);
-  }
+  this->paintScreen(sBuffer);
 }
 
 inline unsigned char* Arduboy::getBuffer(){
   return sBuffer;
 }
 
-uint8_t Arduboy::width() { return WIDTH; }
-
-uint8_t Arduboy::height() { return HEIGHT; }
 
 // returns true if the button mask passed in is pressed
 //
@@ -843,23 +668,6 @@ boolean Arduboy::not_pressed(uint8_t buttons)
 {
  uint8_t button_state = getInput();
  return (button_state & buttons) == 0;
-}
-
-
-uint8_t Arduboy::getInput()
-{
-  // using ports here is ~100 bytes smaller than digitalRead()
-  #ifdef DEVKIT
-  // down, left, up
-  uint8_t buttons = ((~PINB) & B01110000);
-  // right button
-  buttons = buttons | (((~PINC) & B01000000) >> 4);
-  // A and B
-  buttons = buttons | (((~PINF) & B11000000) >> 6);
-  #endif
-
-  // b0dlu0rab - see button defines in Arduboy.h
-  return buttons;
 }
 
 void Arduboy::swap(int16_t& a, int16_t& b) {

--- a/Arduboy.h
+++ b/Arduboy.h
@@ -125,6 +125,7 @@ private:
   unsigned char sBuffer[(HEIGHT*WIDTH)/8];
 
   void bootLCD() __attribute__((always_inline));
+  void bootPins() __attribute__((always_inline));
   void safeMode() __attribute__((always_inline));
   void slowCPU() __attribute__((always_inline));
   uint8_t readCapacitivePin(int pinToMeasure);

--- a/Arduboy.h
+++ b/Arduboy.h
@@ -62,7 +62,7 @@ public:
   void setCursor(int16_t x, int16_t y);
   void setTextSize(uint8_t s);
   void setTextWrap(boolean w);
-  inline unsigned char* getBuffer();
+  unsigned char* getBuffer();
   virtual size_t write(uint8_t);
   void initRandomSeed();
   void swap(int16_t& a, int16_t& b);

--- a/Arduboy.h
+++ b/Arduboy.h
@@ -1,13 +1,11 @@
 #ifndef Arduboy_h
 #define Arduboy_h
 
+#include "core.h"
 #include <SPI.h>
 #include <Print.h>
-#include <avr/sleep.h>
-#include <avr/power.h>
 #include <limits.h>
 
-#define DEVKIT
 
 // EEPROM settings
 
@@ -21,11 +19,7 @@
 #include "audio.h"
 
 #define PIXEL_SAFE_MODE
-#define SAFE_MODE
 
-#define CS 6
-#define DC 4
-#define RST 12
 
 // compare Vcc to 1.1 bandgap
 #define ADC_VOLTAGE _BV(REFS0) | _BV(MUX4) | _BV(MUX3) | _BV(MUX2) | _BV(MUX1)
@@ -33,51 +27,19 @@
 // also _BV(MUX5)
 #define ADC_TEMP _BV(REFS0) | _BV(REFS1) | _BV(MUX2) | _BV(MUX1) | _BV(MUX0)
 
-#define LEFT_BUTTON _BV(5)
-#define RIGHT_BUTTON _BV(2)
-#define UP_BUTTON _BV(4)
-#define DOWN_BUTTON _BV(6)
-#define A_BUTTON _BV(1)
-#define B_BUTTON _BV(0)
-
-#define PIN_LEFT_BUTTON 9
-#define PIN_RIGHT_BUTTON 5
-#define PIN_UP_BUTTON 8
-#define PIN_DOWN_BUTTON 10
-#define PIN_A_BUTTON A0
-#define PIN_B_BUTTON A1
-
 #define PIN_SPEAKER_1 A2
 #define PIN_SPEAKER_2 A3
 
-#define WIDTH 128
-#define HEIGHT 64
-
-#define WHITE 1
-#define BLACK 0
-
-#define COLUMN_ADDRESS_END (WIDTH - 1) & 0x7F
-#define PAGE_ADDRESS_END ((HEIGHT/8)-1) & 0x07
-
-
-class Arduboy : public Print
+class Arduboy : public Print, public ArduboyCore
 {
 public:
   Arduboy();
-  void LCDDataMode();
-  void LCDCommandMode();
 
-  uint8_t getInput();
   boolean pressed(uint8_t buttons);
   boolean not_pressed(uint8_t buttons);
   void start();
-  void saveMuchPower();
-  void idle();
-  void blank();
   void clearDisplay();
   void display();
-  void drawScreen(const unsigned char *image);
-  void drawScreen(unsigned char image[]);
   void drawPixel(int x, int y, uint8_t color);
   uint8_t getPixel(uint8_t x, uint8_t y);
   void drawCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color);
@@ -101,8 +63,6 @@ public:
   void setTextSize(uint8_t s);
   void setTextWrap(boolean w);
   inline unsigned char* getBuffer();
-  uint8_t width();
-  uint8_t height();
   virtual size_t write(uint8_t);
   void initRandomSeed();
   void swap(int16_t& a, int16_t& b);
@@ -124,15 +84,9 @@ public:
 private:
   unsigned char sBuffer[(HEIGHT*WIDTH)/8];
 
-  void bootLCD() __attribute__((always_inline));
-  void bootPins() __attribute__((always_inline));
-  void safeMode() __attribute__((always_inline));
-  void slowCPU() __attribute__((always_inline));
   uint8_t readCapacitivePin(int pinToMeasure);
   uint8_t readCapXtal(int pinToMeasure);
   uint16_t rawADC(byte adc_bits);
-  volatile uint8_t *mosiport, *clkport, *csport, *dcport;
-  uint8_t mosipinmask, clkpinmask, cspinmask, dcpinmask;
 
 // Adafruit stuff
 protected:

--- a/core.cpp
+++ b/core.cpp
@@ -110,6 +110,8 @@ void ArduboyCore::bootLCD()
   dcport = portOutputRegister(digitalPinToPort(DC));
   dcpinmask = digitalPinToBitMask(DC);
 
+  SPI.setClockDivider(SPI_CLOCK_DIV2);
+
   LCDCommandMode();
   for (int8_t i=0; i < sizeof(lcdBootProgram); i++) {
     SPI.transfer(pgm_read_byte(lcdBootProgram + i));

--- a/core.cpp
+++ b/core.cpp
@@ -188,11 +188,23 @@ void ArduboyCore::paintScreen(const unsigned char *image)
   }
 }
 
+// paint from a memory buffer, this should be FAST as it's likely what
+// will be used by any buffer based subclass
 void ArduboyCore::paintScreen(unsigned char image[])
 {
   for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
   {
-    SPI.transfer(image[i]);
+    // SPI.transfer(image[i]);
+
+    // we need to burn 18 cycles between sets of SPDR
+    // 4 clock cycles
+    SPDR = image[i];
+    // 7 clock cycles
+    asm volatile(
+      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
+      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
+      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
+      );
   }
 }
 

--- a/core.cpp
+++ b/core.cpp
@@ -133,11 +133,6 @@ void ArduboyCore::LCDCommandMode()
 
 
 
-// Safe Mode is engaged by holding down both the LEFT button and UP button
-// when plugging the device into USB.  It puts your device into a tight
-// loop and allows it to be reprogrammed even if you have uploaded a very
-// broken sketch that interferes with the normal USB triggered auto-reboot
-// functionality of the device.
 void ArduboyCore::safeMode()
 {
   blank(); // too avoid random gibberish

--- a/core.cpp
+++ b/core.cpp
@@ -1,0 +1,222 @@
+#include "core.h"
+
+const uint8_t PROGMEM lcdBootProgram[] = {
+  0xAE,  // Display Off
+  0XD5,  // Set Display Clock Divisor v
+  0xF0,  //   0x80 is default
+  0xA8,  // Set Multiplex Ratio v
+  0x3F,
+  0xD3,  // Set Display Offset v
+  0x00,
+  0x40,  // Set Start Line (0)
+  0x8D,  // Charge Pump Setting v
+  0x14,  //   Enable
+  // running this next pair twice?
+  0x20,  // Set Memory Mode v
+  0x00,  //   Horizontal Addressing
+  0xA1,  // Set Segment Re-map (A0) | (b0001)
+  0xC8,  // Set COM Output Scan Direction
+  0xDA,  // Set COM Pins v
+  0x12,
+  0x81,  // Set Contrast v
+  0xCF,
+  0xD9,  // Set Precharge
+  0xF1,
+  0xDB,  // Set VCom Detect
+  0x40,
+  0xA4,  // Entire Display ON
+  0xA6,  // Set normal/inverse display
+  0xAF,  // Display On
+
+  0x20,     // set display mode
+  0x00,     // horizontal addressing mode
+
+  0x21,     // set col address
+  0x00,
+  COLUMN_ADDRESS_END,
+
+  0x22, // set page address
+  0x00,
+  PAGE_ADDRESS_END
+};
+
+
+ArduboyCore::ArduboyCore() {}
+
+// meant to be overridden by subclasses
+void ArduboyCore::setup()
+{
+  boot();
+}
+
+void ArduboyCore::boot()
+{
+  #if F_CPU == 8000000L
+  slowCPU();
+  #endif
+
+  SPI.begin();
+  bootPins();
+  bootLCD();
+
+  #ifdef SAFE_MODE
+  if (getInput() == (LEFT_BUTTON | UP_BUTTON))
+    safeMode();
+  #endif
+
+  saveMuchPower();
+}
+
+#if F_CPU == 8000000L
+// if we're compiling for 8Mhz we need to slow the CPU down because the
+// hardware clock on the Arduboy is 16MHz
+void ArduboyCore::slowCPU()
+{
+  uint8_t oldSREG = SREG;
+  cli();                // suspend interrupts
+  CLKPR = _BV(CLKPCE);  // allow reprogramming clock
+  CLKPR = 1;            // set clock divisor to 2 (0b0001)
+  SREG = oldSREG;       // restore interrupts
+}
+#endif
+
+void ArduboyCore::bootPins()
+{
+  // OLED SPI
+  pinMode(DC, OUTPUT);
+  pinMode(CS, OUTPUT);
+  pinMode(RST, OUTPUT);
+  digitalWrite(RST, HIGH);
+  delay(1);           // VDD (3.3V) goes high at start, lets just chill for a ms
+  digitalWrite(RST, LOW);   // bring reset low
+  delay(10);          // wait 10ms
+  digitalWrite(RST, HIGH);  // bring out of reset
+
+  // Buttons
+  pinMode(PIN_LEFT_BUTTON, INPUT_PULLUP);
+  pinMode(PIN_RIGHT_BUTTON, INPUT_PULLUP);
+  pinMode(PIN_UP_BUTTON, INPUT_PULLUP);
+  pinMode(PIN_DOWN_BUTTON, INPUT_PULLUP);
+  pinMode(PIN_A_BUTTON, INPUT_PULLUP);
+  pinMode(PIN_B_BUTTON, INPUT_PULLUP);
+
+}
+
+void ArduboyCore::bootLCD()
+{
+  // setup the ports we need to talk to the OLED
+  csport = portOutputRegister(digitalPinToPort(CS));
+  cspinmask = digitalPinToBitMask(CS);
+  dcport = portOutputRegister(digitalPinToPort(DC));
+  dcpinmask = digitalPinToBitMask(DC);
+
+  LCDCommandMode();
+  for (int8_t i=0; i < sizeof(lcdBootProgram); i++) {
+    SPI.transfer(pgm_read_byte(lcdBootProgram + i));
+  }
+  LCDDataMode();
+}
+
+void ArduboyCore::LCDDataMode()
+{
+  *dcport |= dcpinmask;
+  *csport &= ~cspinmask;
+}
+
+void ArduboyCore::LCDCommandMode()
+{
+  *csport |= cspinmask; // why are we doing this twice?
+  *csport |= cspinmask;
+  *dcport &= ~dcpinmask;
+  *csport &= ~cspinmask;
+}
+
+
+
+// Safe Mode is engaged by holding down both the LEFT button and UP button
+// when plugging the device into USB.  It puts your device into a tight
+// loop and allows it to be reprogrammed even if you have uploaded a very
+// broken sketch that interferes with the normal USB triggered auto-reboot
+// functionality of the device.
+void ArduboyCore::safeMode()
+{
+  blank(); // too avoid random gibberish
+  while (true) {
+    asm volatile("nop \n");
+  }
+}
+
+
+/* Power Management */
+
+void ArduboyCore::idle()
+{
+  set_sleep_mode(SLEEP_MODE_IDLE);
+  sleep_mode();
+}
+
+void ArduboyCore::saveMuchPower()
+{
+  power_adc_disable();
+  power_usart0_disable();
+  power_twi_disable();
+  // timer 0 is for millis()
+  // timers 1 and 3 are for music and sounds
+  power_timer2_disable();
+  power_usart1_disable();
+  // we need USB, for now (to allow triggered reboots to reprogram)
+  // power_usb_disable()
+}
+
+uint8_t ArduboyCore::width() { return WIDTH; }
+
+uint8_t ArduboyCore::height() { return HEIGHT; }
+
+
+/* Drawing */
+
+void ArduboyCore::paint8Pixels(uint8_t pixels)
+{
+  SPI.transfer(pixels);
+}
+
+void ArduboyCore::paintScreen(const unsigned char *image)
+{
+  for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
+  {
+    SPI.transfer(pgm_read_byte(image + i));
+  }
+}
+
+void ArduboyCore::paintScreen(unsigned char image[])
+{
+  for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
+  {
+    SPI.transfer(image[i]);
+  }
+}
+
+void ArduboyCore::blank()
+{
+  for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
+    SPI.transfer(0x00);
+}
+
+
+/* Buttons */
+
+uint8_t ArduboyCore::getInput()
+{
+  // using ports here is ~100 bytes smaller than digitalRead()
+  #ifdef DEVKIT
+  // down, left, up
+  uint8_t buttons = ((~PINB) & B01110000);
+  // right button
+  buttons = buttons | (((~PINC) & B01000000) >> 4);
+  // A and B
+  buttons = buttons | (((~PINF) & B11000000) >> 6);
+  #endif
+
+  // b0dlu0rab - see button defines in Arduboy.h
+  return buttons;
+}

--- a/core.h
+++ b/core.h
@@ -1,0 +1,108 @@
+#ifndef ArduboyCore_h
+#define ArduboyCore_h
+
+#include <avr/power.h>
+#include <SPI.h>
+#include <avr/sleep.h>
+#include <limits.h>
+
+#define SAFE_MODE
+#define DEVKIT
+
+#define CS 6
+#define DC 4
+#define RST 12
+
+#define PIN_LEFT_BUTTON 9
+#define PIN_RIGHT_BUTTON 5
+#define PIN_UP_BUTTON 8
+#define PIN_DOWN_BUTTON 10
+#define PIN_A_BUTTON A0
+#define PIN_B_BUTTON A1
+
+#define LEFT_BUTTON _BV(5)
+#define RIGHT_BUTTON _BV(2)
+#define UP_BUTTON _BV(4)
+#define DOWN_BUTTON _BV(6)
+#define A_BUTTON _BV(1)
+#define B_BUTTON _BV(0)
+
+#define COLUMN_ADDRESS_END (WIDTH - 1) & 0x7F
+#define PAGE_ADDRESS_END ((HEIGHT/8)-1) & 0x07
+
+#define WIDTH 128
+#define HEIGHT 64
+
+#define WHITE 1
+#define BLACK 0
+
+class ArduboyCore
+{
+public:
+    ArduboyCore();
+    void setup();
+    void idle();
+
+    void LCDDataMode();
+    void LCDCommandMode();
+
+    uint8_t width();
+    uint8_t height();
+
+    uint8_t getInput();
+
+    // paints 8 pixels (vertically) from a single byte
+    //  - 1 is lit, 0 is unlit
+    //
+    // NOTE: You probably wouldn't actually use this, you'd build something
+    // higher level that does it's own calls to SPI.transfer().  It's
+    // included for completeness since it seems there should be some very
+    // rudimentary low-level draw function in the core that supports the
+    // minimum unit that the hardware allows (which is a strip of 8 pixels)
+    //
+    // This routine starts in the top left and then across the screen.
+    // After each "page" (row) of 8 pixels is drawn it will shift down
+    // to start drawing the next page.  To paint the full screen you call
+    // this function 1,024 times.
+    //
+    // Example:
+    //
+    // X = painted pixels, . = unpainted
+    //
+    // blank()                      paint8Pixels() 0xFF, 0, 0x0F, 0, 0xF0
+    // v TOP LEFT corner (8x9)      v TOP LEFT corner
+    // ........ (page 1)            X...X... (page 1)
+    // ........                     X...X...
+    // ........                     X...X...
+    // ........                     X...X...
+    // ........                     X.X.....
+    // ........                     X.X.....
+    // ........                     X.X.....
+    // ........ (end of page 1)     X.X..... (end of page 1)
+    // ........ (page 2)            ........ (page 2)
+    void paint8Pixels(uint8_t pixels);
+
+    /// paints an entire image directly to hardware (from PROGMEM)
+    void paintScreen(const unsigned char *image);
+    /// paints an entire image directly to hardware (from RAM)
+    void paintScreen(unsigned char image[]);
+    /// paints a blank screen to hardware
+    void blank();
+
+
+protected:
+    void boot();
+    void bootLCD() __attribute__((always_inline));
+    void bootPins() __attribute__((always_inline));
+    void safeMode() __attribute__((always_inline));
+    void slowCPU() __attribute__((always_inline));
+    void saveMuchPower(); __attribute__((always_inline));
+
+private:
+    volatile uint8_t *mosiport, *clkport, *csport, *dcport;
+    uint8_t mosipinmask, clkpinmask, cspinmask, dcpinmask;
+
+
+};
+
+#endif

--- a/core.h
+++ b/core.h
@@ -20,6 +20,7 @@
 #define PIN_A_BUTTON A0
 #define PIN_B_BUTTON A1
 
+// button states
 #define LEFT_BUTTON _BV(5)
 #define RIGHT_BUTTON _BV(2)
 #define UP_BUTTON _BV(4)
@@ -46,8 +47,27 @@ public:
     void LCDDataMode();
     void LCDCommandMode();
 
-    uint8_t width();
-    uint8_t height();
+    uint8_t width();    //< return display width
+    uint8_t height();   // < return display height
+
+    /// get current state of buttons (bitmask)
+    /**
+    Byte value returned:
+
+    00000000
+    ||||||||
+    |||||||`- A Button
+    ||||||`-- B
+    |||||`--- Right
+    ||||`---- *reserved
+    |||`----- Up
+    ||`------ Left
+    |`------- Down
+    `-------- *reserved
+
+    Of course you shouldn't worry about this and should instead use the
+    button defines: LEFT_BUTTON, A_BUTTON, UP_BUTTON, etc.
+    **/
 
     uint8_t getInput();
 


### PR DESCRIPTION
This is a common pattern (seen in Gamebuino and other libs).  The problem is how to have very different "modes" (buffer, greyscale, tiled, etc.) but a single core lib.  Or even to answer the question of some people who want a terribly slim library vs those that want a LOT more functionality.  The core library can support both ways of thinking.  The answer is create a logical class hierarchy (not even a deep one).  I'd like to propose something like this:

(Print is included below to allow printing to screen, which comes from the Print.cpp Arduino core library)
- ArduboyCore (low-level hardware boot, button polling, power saving, safe mode, etc)
- Arduboy (ArduboyCore, Print, Buffered graphics) - same as today
- ArduboyText (ArduboyCore, Print, buffered text array)
- ArduboyTiled (ArduboyCore, support for array of tiles and buffered scrollable display rendered with tiles)

So pretty much just the core and then the classes MOST people would be using lay in on top of the core to provide the drawing modes, etc.  I'm not even saying all these classes need to be in core... it could be that ArduboyText and ArduboyTiled are developed as separate libraries and maintained in their own right.  Splitting the core hardware stuff into ArduboyCore allows people who want to build these libraries to still take advantage of the core lib, even if they're wanting to do something far different than a buffer backed display.  They still get the same boot up code, power saving, etc...

This encourages people to use the core lib (even if only for ArduboyCore) vs forking it into 5 different variants for different types of displays that do not want a buffer (or want a differently configured buffer).  

This pull request is the beginning of this effort.  It starts by creating ArduboyCore and moving all the hardware level stuff there.  Arduboy becomes a subclass of ArduboyCore and has almost exactly the same API as before.  I change `drawScreen` to `paintScreen` for clarify, but I could add a proxy `drawScreen` back to the `Arduboy` class if that would be helpful.
