### PR TITLE
Add vertical and horizontal display flip functions

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -211,6 +211,32 @@ void ArduboyCore::blank()
     SPI.transfer(0x00);
 }
 
+// flip the display vertically or set to normal
+void ArduboyCore::flipVertical(boolean flip)
+{
+  LCDCommandMode();
+  if (flip) {
+    SPI.transfer(0xC0); // reversed COM scan direction
+  }
+  else {
+    SPI.transfer(0xC8); // normal COM scan direction
+  }
+  LCDDataMode();
+}
+
+// flip the display horizontally or set to normal
+void ArduboyCore::flipHorizontal(boolean flip)
+{
+  LCDCommandMode();
+  if (flip) {
+    SPI.transfer(0xA0); // reversed segment re-map
+  }
+  else {
+    SPI.transfer(0xA1); // normal segment re-map
+  }
+  LCDDataMode();
+}
+
 
 /* Buttons */
 

--- a/core.h
+++ b/core.h
@@ -156,6 +156,12 @@ public:
     /// paints a blank (black) screen to hardware
     void blank();
 
+    /// flip the display vertically or set to normal
+    void flipVertical(boolean flip);
+
+    /// flip the display horizontally or set to normal
+    void flipHorizontal(boolean flip);
+
 
 protected:
     /// boots the hardware


### PR DESCRIPTION
Adds **flipVertical()** and **flipHorizontal()** user functions to the core library. These send the appropriate commands to the SSD1306 display controller to flip (mirror) the contents of the display vertically or horizontally. If both are used, the display contents will be upside down.

If the boolean parameter passed to the function is _true_, the display will be set to flipped. If _false_, the display will be set to normal. After one of these function is used, the display will remain in that state until changed again, or the display is reset.

Are these useful for the Arduboy? They could be used to set the 0, 0 origin of pixel functions to any corner (and affected X/Y directions). Of course, any text output and bitmaps will be flipped accordingly.
