### PR TITLE
Optimised fillScreen function

### DIFF
--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -359,6 +359,10 @@ void Arduboy::fillRect
 
 void Arduboy::fillScreen(uint8_t color)
 {
+  // C version : 
+  //if(color != 0) color = 0xFF;  //change any nonzero argument to b11111111 and insert into screen array.
+  //for(int16_t i=0; i<1024; i++)  { sBuffer[i] = color; }  //sBuffer = (128*64) = 8192/8 = 1024 bytes. 
+  
   asm volatile
   (
     // load color value into r27

--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -383,9 +383,12 @@ void Arduboy::fillRect
 
 void Arduboy::fillScreen(uint8_t color)
 {
-  for(int16_t i=0; i<1024; i++) //1024 = (128*64)/8
+  color *= 0xFF;
   {
-    sBuffer[i] = color*256;     //if c=0, b00000000. if c=1, b=11111111
+    for(int16_t i=0; i<1024; i++) //1024 = (128*64)/8
+    {
+      sBuffer[i] = color;
+    }
   }
 }
 

--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -383,7 +383,10 @@ void Arduboy::fillRect
 
 void Arduboy::fillScreen(uint8_t color)
 {
-  fillRect(0, 0, WIDTH, HEIGHT, color);
+  for(int16_t i=0; i<1024; i++) //1024 = (128*64)/8
+  {
+    sBuffer[i] = color*256;     //if c=0, b00000000. if c=1, b=11111111
+  }
 }
 
 void Arduboy::drawRoundRect

--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -105,31 +105,7 @@ uint16_t Arduboy::rawADC(byte adc_bits)
 
 void Arduboy::clearDisplay()
 {
-  // C version:
-  // for (int a = 0; a < (HEIGHT*WIDTH)/8; a++) sBuffer[a] = 0x00;
-
-  // This implimentation should be close to an order of magnitude faster
-  asm volatile(
-    // load sBuffer pointer into Z
-    "movw  r30, %0\n\t"
-    // counter = 0
-    "eor __tmp_reg__, __tmp_reg__ \n\t"
-    "loop:   \n\t"
-    // (4x) push zero into screen buffer,
-    // then increment buffer position
-    "st Z+, __zero_reg__ \n\t"
-    "st Z+, __zero_reg__ \n\t"
-    "st Z+, __zero_reg__ \n\t"
-    "st Z+, __zero_reg__ \n\t"
-    // increase counter
-    "inc __tmp_reg__ \n\t"
-    // repeat for 256 loops
-    // (until counter rolls over back to 0)
-    "brne loop \n\t"
-    // input: sBuffer
-    // modified: Z (r30, r31)
-    : : "r" (sBuffer) : "r30","r31"
-  );
+  this->fillScreen(0);
 }
 
 void Arduboy::drawPixel(int x, int y, uint8_t color)


### PR DESCRIPTION
Could possibly go even faster with bithax, but this is already much faster than using fillrect as there is no need for bounds checking. This should eliminate the need to do fiddly overdrawing such as in the breakout example, which will help with code clarity.

Works by setting every bit in every byte to the input color, doesn't require any code changes and only slightly increases library size.
If color is 0, B00000000
if color is 1, B11111111
