### PR TITLE
New Invert() and allPixelsOn() display functions

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -211,6 +211,32 @@ void ArduboyCore::blank()
     SPI.transfer(0x00);
 }
 
+// flip the display vertically or set to normal
+void ArduboyCore::flipVertical(boolean flip)
+{
+  LCDCommandMode();
+  if (flip) {
+    SPI.transfer(0xC0); // reversed COM scan direction
+  }
+  else {
+    SPI.transfer(0xC8); // normal COM scan direction
+  }
+  LCDDataMode();
+}
+
+// flip the display horizontally or set to normal
+void ArduboyCore::flipHorizontal(boolean flip)
+{
+  LCDCommandMode();
+  if (flip) {
+    SPI.transfer(0xA0); // reversed segment re-map
+  }
+  else {
+    SPI.transfer(0xA1); // normal segment re-map
+  }
+  LCDDataMode();
+}
+
 
 /* Buttons */
 

--- a/core.cpp
+++ b/core.cpp
@@ -211,6 +211,21 @@ void ArduboyCore::blank()
     SPI.transfer(0x00);
 }
 
+
+// invert the display or set to normal
+// when inverted, a pixel set to 0 will be on
+void ArduboyCore::invert(boolean inverse)
+{
+  LCDCommandMode();
+  if (inverse) {
+    SPI.transfer(0xA7); // inverse display
+  }
+  else {
+    SPI.transfer(0xA6); // normal display
+  }
+  LCDDataMode();
+}
+
 // flip the display vertically or set to normal
 void ArduboyCore::flipVertical(boolean flip)
 {

--- a/core.cpp
+++ b/core.cpp
@@ -252,6 +252,19 @@ void ArduboyCore::flipHorizontal(boolean flip)
   LCDDataMode();
 }
 
+// turn all display pixels on, ignoring buffer contents
+void ArduboyCore::allOn(boolean on)
+{
+  LCDCommandMode();
+  if (on) {
+    SPI.transfer(0xA5); // all pixels on
+  }
+  else {
+    SPI.transfer(0xA4); // normal display
+  }
+  LCDDataMode();
+}
+
 
 /* Buttons */
 

--- a/core.cpp
+++ b/core.cpp
@@ -253,7 +253,7 @@ void ArduboyCore::flipHorizontal(boolean flip)
 }
 
 // turn all display pixels on, ignoring buffer contents
-void ArduboyCore::allOn(boolean on)
+void ArduboyCore::allPixelsOn(boolean on)
 {
   LCDCommandMode();
   if (on) {

--- a/core.h
+++ b/core.h
@@ -156,6 +156,12 @@ public:
     /// paints a blank (black) screen to hardware
     void blank();
 
+    /// invert the display or set to normal
+    /**
+     * when inverted, a pixel set to 0 will be on
+     */
+    void invert(boolean inverse);
+
     /// flip the display vertically or set to normal
     void flipVertical(boolean flip);
 

--- a/core.h
+++ b/core.h
@@ -169,7 +169,7 @@ public:
     void flipHorizontal(boolean flip);
 
     /// turn all display pixels on, ignoring buffer contents
-    void allOn(boolean on);
+    void allPixelsOn(boolean on);
 
 protected:
     /// boots the hardware

--- a/core.h
+++ b/core.h
@@ -156,6 +156,12 @@ public:
     /// paints a blank (black) screen to hardware
     void blank();
 
+    /// flip the display vertically or set to normal
+    void flipVertical(boolean flip);
+
+    /// flip the display horizontally or set to normal
+    void flipHorizontal(boolean flip);
+
 
 protected:
     /// boots the hardware

--- a/core.h
+++ b/core.h
@@ -168,6 +168,8 @@ public:
     /// flip the display horizontally or set to normal
     void flipHorizontal(boolean flip);
 
+    /// turn all display pixels on, ignoring buffer contents
+    void allOn(boolean on);
 
 protected:
     /// boots the hardware


### PR DESCRIPTION
Added functions _invert()_ and _allOn()_ to the core library.

The _invert()_ function will command the display controller to invert the display. A pixel set to 1 will be off and vice versa. If the argument is _true_, the display will be inverted. If the argument is _false_ the display will be set to normal. An inverted display remains in effect until set back to normal or the display controller is reset.

Possible uses for this function:
- If having a white background with black objects is desired, it may be easier to work with an inverted display.
- Can be used to create effects such as explosions, lightning or a visual alert by briefly inverting the display and then setting it back to normal once or a few times.
- If what is being displayed is mostly a dark background with white objects, inverting the display during development of a program can help aid in determining if the location of an object is correct because the pixels between the objects become visible and the edge of the screen is easy to see.

The _allOn()_ function will command the display controller to set all pixels on, without affecting the contents of the display's RAM buffer. All pixels will turn on even if the display has been inverted using the above _invert()_ function. A _true_ argument will turn all pixels on and a _false_ argument will return to the previous display state.

Similar to the _invert()_ function, this _allOn()_ function could be used to simulate explosions or other flashes.
