### PR TITLE
Add invert() and allPixelsOn() display functions

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -231,6 +231,26 @@ void ArduboyCore::sendLCDCommand(uint8_t command)
   LCDDataMode();
 }
 
+#define OLED_PIXELS_INVERTED 0xA7 // All pixels inverted
+#define OLED_PIXELS_NORMAL 0xA6 // All pixels normal
+
+// invert the display or set to normal
+// when inverted, a pixel set to 0 will be on
+void ArduboyCore::invert(boolean inverse)
+{
+  sendLCDCommand(inverse ? OLED_PIXELS_INVERTED : OLED_PIXELS_NORMAL);
+}
+
+#define OLED_ALL_PIXELS_ON 0xA5 // all pixels on
+#define OLED_PIXELS_FROM_RAM 0xA4 // pixels mapped to display RAM contents
+
+// turn all display pixels on, ignoring buffer contents
+// or set to normal buffer display
+void ArduboyCore::allPixelsOn(boolean on)
+{
+  sendLCDCommand(on ? OLED_ALL_PIXELS_ON : OLED_PIXELS_FROM_RAM);
+}
+
 #define OLED_VERTICAL_FLIPPED 0xC0 // reversed COM scan direction
 #define OLED_VERTICAL_NORMAL 0xC8 // normal COM scan direction
 

--- a/core.h
+++ b/core.h
@@ -156,6 +156,19 @@ public:
     /// paints a blank (black) screen to hardware
     void blank();
 
+    /// invert the display or set to normal
+    /**
+     * when inverted, a pixel set to 0 will be on
+     */
+    void invert(boolean inverse);
+
+    /// turn all display pixels on, or display the buffer contents
+    /**
+     * when set to all pixels on, the display buffer will be
+     * ignored but not altered
+     */
+    void allPixelsOn(boolean on);
+
     /// flip the display vertically or set to normal
     void flipVertical(boolean flipped);
 


### PR DESCRIPTION
invert(true) will invert the display so a 0 bit in the buffer will
turn the corresponding pixel on. invert(false) will set to normal.

allPixelsOn(true) will set all pixels on, ignoring the contents of
the buffer but leaving it unaltered. allPixelsOn(false) will display
the contents of the buffer.

See the discussion in obsolete pull request #46 for more info.
