### PR TITLE
small flash memory savings add up (50 bytes)

### DIFF
--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -3,14 +3,16 @@
 
 Arduboy::Arduboy()
 {
-  frameRate = 60;
+  // frame management
+  setFrameRate(60);
   frameCount = 0;
-  eachFrameMillis = 1000/60;
-  lastFrameStart = 0;
   nextFrameStart = 0;
   post_render = false;
-  lastFrameDurationMs = 0;
-  
+  // init not necessary, will be reset after first use
+  // lastFrameStart
+  // lastFrameDurationMs
+
+  // font rendering  
   cursor_x = 0;
   cursor_y = 0;
   textsize = 1;

--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -640,7 +640,8 @@ void Arduboy::setCursor(int16_t x, int16_t y)
 
 void Arduboy::setTextSize(uint8_t s)
 {
-  textsize = (s > 0) ? s : 1;
+  // textsize must always be 1 or higher
+  textsize = max(1,s); 
 }
 
 void Arduboy::setTextWrap(boolean w)

--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -666,8 +666,9 @@ size_t Arduboy::write(uint8_t c)
     cursor_x += textsize*6;
     if (wrap && (cursor_x > (WIDTH - textsize*6)))
     {
-      cursor_y += textsize*8;
-      cursor_x = 0;
+      // calling ourselves recursively for 'newline' is 
+      // 12 bytes smaller than doing the same math here
+      write('\n');
     }
   }
 }

--- a/Arduboy.h
+++ b/Arduboy.h
@@ -184,8 +184,6 @@ public:
 protected:
   unsigned char sBuffer[(HEIGHT*WIDTH)/8];
 
-  uint8_t readCapacitivePin(int pinToMeasure);
-  uint8_t readCapXtal(int pinToMeasure);
 
 // Adafruit stuff
 protected:

--- a/core.cpp
+++ b/core.cpp
@@ -17,43 +17,37 @@ const uint8_t PROGMEM pinBootProgram[] = {
 };
 
 const uint8_t PROGMEM lcdBootProgram[] = {
-  0xAE,  // Display Off
-  0XD5,  // Set Display Clock Divisor v
-  0xF0,  //   0x80 is default
-  0xA8,  // Set Multiplex Ratio v
-  0x3F,
-  0xD3,  // Set Display Offset v
-  0x00,
-  0x40,  // Set Start Line (0)
-  0x8D,  // Charge Pump Setting v
-  0x14,  //   Enable
-  // running this next pair twice?
-  0x20,  // Set Memory Mode v
-  0x00,  //   Horizontal Addressing
-  0xA1,  // Set Segment Re-map (A0) | (b0001)
-  0xC8,  // Set COM Output Scan Direction
-  0xDA,  // Set COM Pins v
-  0x12,
-  0x81,  // Set Contrast v
-  0xCF,
-  0xD9,  // Set Precharge
-  0xF1,
-  0xDB,  // Set VCom Detect
-  0x40,
-  0xA4,  // Entire Display ON
-  0xA6,  // Set normal/inverse display
-  0xAF,  // Display On
-
+  0xAE,     // Display Off
+  0XD5,     // Set Display Clock Divisor v
+    0xF0,   //   0x80 is default
+  0xA8,     // Set Multiplex Ratio v
+    0x3F,   
+  0xD3,     // Set Display Offset v
+    0x00,   
+  0x40,     // Set Start Line (0)
+  0x8D,     // Charge Pump Setting v
+    0x14,   //   Enable
+  0xA1,     // Set Segment Re-map (A0) | (b0001)
+  0xC8,     // Set COM Output Scan Direction
+  0xDA,     // Set COM Pins v
+    0x12,   
+  0x81,     // Set Contrast v
+    0xCF,   
+  0xD9,     // Set Precharge
+    0xF1,   
+  0xDB,     // Set VCom Detect
+    0x40,   
+  0xA4,     // Entire Display ON
+  0xA6,     // Set normal/inverse display
+  0xAF,     // Display On
   0x20,     // set display mode
-  0x00,     // horizontal addressing mode
-
+    0x00,   // horizontal addressing mode
   0x21,     // set col address
-  0x00,
-  COLUMN_ADDRESS_END,
-
-  0x22, // set page address
-  0x00,
-  PAGE_ADDRESS_END
+    0x00,
+    COLUMN_ADDRESS_END,
+  0x22,     // set page address
+    0x00,
+    PAGE_ADDRESS_END
 };
 
 

--- a/core.cpp
+++ b/core.cpp
@@ -140,7 +140,6 @@ void ArduboyCore::LCDDataMode()
 
 void ArduboyCore::LCDCommandMode()
 {
-  *csport |= cspinmask; // why are we doing this twice?
   *csport |= cspinmask;
   *dcport &= ~dcpinmask;
   *csport &= ~cspinmask;

--- a/core.cpp
+++ b/core.cpp
@@ -17,37 +17,42 @@ const uint8_t PROGMEM pinBootProgram[] = {
 };
 
 const uint8_t PROGMEM lcdBootProgram[] = {
-  0xAE,     // Display Off
+  // boot defaults are commented out but left here incase they
+  // might prove useful for reference
+  //
+  // Further reading: https://www.adafruit.com/datasheets/SSD1306.pdf
+  //
+  // 0xAE,     // Display Off
   0XD5,     // Set Display Clock Divisor v
     0xF0,   //   0x80 is default
-  0xA8,     // Set Multiplex Ratio v
-    0x3F,   
-  0xD3,     // Set Display Offset v
-    0x00,   
-  0x40,     // Set Start Line (0)
+  // 0xA8,     // Set Multiplex Ratio v
+    // 0x3F,   
+  // 0xD3,     // Set Display Offset v
+    // 0x00,   
+  // 0x40,     // Set Start Line (0)
   0x8D,     // Charge Pump Setting v
     0x14,   //   Enable
   0xA1,     // Set Segment Re-map (A0) | (b0001)
   0xC8,     // Set COM Output Scan Direction
-  0xDA,     // Set COM Pins v
-    0x12,   
+  // 0xDA,     // Set COM Pins v
+    // 0x12,   
   0x81,     // Set Contrast v
     0xCF,   
   0xD9,     // Set Precharge
     0xF1,   
-  0xDB,     // Set VCom Detect
-    0x40,   
-  0xA4,     // Entire Display ON
-  0xA6,     // Set normal/inverse display
+  // 0xDB,     // Set VCom Detect
+    // 0x40,   
+  // 0xA4,     // Entire Display ON
+  // 0xA6,     // Set normal/inverse display
   0xAF,     // Display On
   0x20,     // set display mode
     0x00,   // horizontal addressing mode
-  0x21,     // set col address
-    0x00,
-    COLUMN_ADDRESS_END,
-  0x22,     // set page address
-    0x00,
-    PAGE_ADDRESS_END
+  // 0x21,     // set col address
+  //   0x00,
+  //   COLUMN_ADDRESS_END,
+  // 0x22,     // set page address
+  //   0x00,
+  //   PAGE_ADDRESS_END
 };
 
 
@@ -120,6 +125,8 @@ void ArduboyCore::bootLCD()
   SPI.setClockDivider(SPI_CLOCK_DIV2);
 
   LCDCommandMode();
+  // run our customized boot-up command sequence against the
+  // OLED to initialize it properly for Arduboy
   for (int8_t i=0; i < sizeof(lcdBootProgram); i++) {
     SPI.transfer(pgm_read_byte(lcdBootProgram + i));
   }

--- a/core.cpp
+++ b/core.cpp
@@ -22,37 +22,62 @@ const uint8_t PROGMEM lcdBootProgram[] = {
   //
   // Further reading: https://www.adafruit.com/datasheets/SSD1306.pdf
   //
-  // 0xAE,     // Display Off
-  0XD5,     // Set Display Clock Divisor v
-    0xF0,   //   0x80 is default
-  // 0xA8,     // Set Multiplex Ratio v
-    // 0x3F,   
-  // 0xD3,     // Set Display Offset v
-    // 0x00,   
-  // 0x40,     // Set Start Line (0)
-  0x8D,     // Charge Pump Setting v
-    0x14,   //   Enable
-  0xA1,     // Set Segment Re-map (A0) | (b0001)
-  0xC8,     // Set COM Output Scan Direction
-  // 0xDA,     // Set COM Pins v
-    // 0x12,   
-  0x81,     // Set Contrast v
-    0xCF,   
-  0xD9,     // Set Precharge
-    0xF1,   
-  // 0xDB,     // Set VCom Detect
-    // 0x40,   
-  // 0xA4,     // Entire Display ON
-  // 0xA6,     // Set normal/inverse display
-  0xAF,     // Display On
-  0x20,     // set display mode
-    0x00,   // horizontal addressing mode
-  // 0x21,     // set col address
-  //   0x00,
-  //   COLUMN_ADDRESS_END,
-  // 0x22,     // set page address
-  //   0x00,
-  //   PAGE_ADDRESS_END
+  // Display Off
+  // 0xAE,     
+
+  // Set Display Clock Divisor v = 0xF0
+  // default is 0x80
+  0xD5, 0xF0,
+
+  // Set Multiplex Ratio v = 0x3F
+  // 0xA8, 0x3F,   
+
+  // Set Display Offset v = 0
+  // 0xD3, 0x00, 
+
+  // Set Start Line (0)
+  // 0x40,     
+
+  // Charge Pump Setting v = enable (0x14)
+  // default is disabled
+  0x8D, 0x14,   
+
+  // Set Segment Re-map (A0) | (b0001)
+  // default is (b0000)
+  0xA1,     
+
+  // Set COM Output Scan Direction
+  0xC8,     
+
+  // Set COM Pins v
+  // 0xDA, 0x12,   
+
+  // Set Contrast v = 0xCF
+  0x81, 0xCF,   
+
+  // Set Precharge = 0xF1
+  0xD9, 0xF1,
+    
+  // Set VCom Detect
+  // 0xDB, 0x40,   
+
+  // Entire Display ON
+  // 0xA4,     
+
+  // Set normal/inverse display
+  // 0xA6,  
+
+  // Display On
+  0xAF,     
+
+  // set display mode = horizontal addressing mode (0x00)
+  0x20, 0x00,  
+
+  // set col address range 
+  // 0x21, 0x00, COLUMN_ADDRESS_END,
+
+  // set page address range
+  // 0x22, 0x00, PAGE_ADDRESS_END
 };
 
 

--- a/core.h
+++ b/core.h
@@ -273,8 +273,8 @@ protected:
 
 
 private:
-    volatile uint8_t *mosiport, *clkport, *csport, *dcport;
-    uint8_t mosipinmask, clkpinmask, cspinmask, dcpinmask;
+    volatile uint8_t *mosiport, *csport, *dcport;
+    uint8_t mosipinmask, cspinmask, dcpinmask;
 
 };
 


### PR DESCRIPTION
- saves 10 bytes
- two variables do not need default values
- cheaper to call setFrameRate and let it assign defaults
