### PR TITLE
Fix FloatyBall bug flagged by compile warning

### DIFF
--- a/examples/FloatyBall/FloatyBall.ino
+++ b/examples/FloatyBall/FloatyBall.ino
@@ -228,7 +228,7 @@ void loop() {
         gameState = 2;                        // Game over. State is 2.
       }
       // Collision checking
-      for (int x = 0; x < 6; x++) {             // For each pipe array element
+      for (int x = 0; x < pipeArraySize; x++) { // For each pipe array element
         if (pipes[0][x] != 255) {               // If the pipe is active (not 255)
           if (checkPipe(x)) { gameState = 2; }  // If the check is true, game over
         }


### PR DESCRIPTION
Currently the example sketch FloatyBall generates a compile warning:

```
FloatyBall/FloatyBall.ino:232:23: warning: iteration 4u invokes undefined behavior [-Waggressive-loop-optimizations]
         if (pipes[0][x] != 255) {               // If the pipe is active (not 255)
                       ^
FloatyBall/FloatyBall.ino:231:7: note: containing loop
       for (int x = 0; x < 6; x++) {             // For each pipe array element
       ^
```

the array _pipes_ is defined as follows:

``` cpp
const int pipeArraySize = 4;  // For the for loops, at current settings only 3 sets of pipes can be onscreen at once
int pipes[2][pipeArraySize];  // Row 0 for x values, row 1 for gap location
```

The loop that generates the warning is:

``` cpp
      // Collision checking
      for (int x = 0; x < 6; x++) {             // For each pipe array element
        if (pipes[0][x] != 255) {               // If the pipe is active (not 255)
          if (checkPipe(x)) { gameState = 2; }  // If the check is true, game over
        }
      }
```

So I think the warning is that variable _x_ can go to 5 but the array index maximum is 3.
I think the _for_ statement should actually be (as it is everywhere else):

``` cpp
      for (int x = 0; x < pipeArraySize; x++) {             // For each pipe array element
```

Changing it to this eliminates the warning.

Merge this pull request if it is agreed that this is the proper fix.
