### PR TITLE
uint8_t for width, height, radius arguments

### DIFF
--- a/Arduboy.cpp
+++ b/Arduboy.cpp
@@ -163,7 +163,7 @@ uint8_t Arduboy::getPixel(uint8_t x, uint8_t y)
   return (sBuffer[(row*WIDTH) + x] & _BV(bit_position)) >> bit_position;
 }
 
-void Arduboy::drawCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color)
+void Arduboy::drawCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color)
 {
   int16_t f = 1 - r;
   int16_t ddF_x = 1;
@@ -201,7 +201,7 @@ void Arduboy::drawCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color)
 }
 
 void Arduboy::drawCircleHelper
-(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint8_t color)
+(int16_t x0, int16_t y0, uint8_t r, uint8_t cornername, uint8_t color)
 {
   int16_t f = 1 - r;
   int16_t ddF_x = 1;
@@ -245,14 +245,14 @@ void Arduboy::drawCircleHelper
   }
 }
 
-void Arduboy::fillCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color)
+void Arduboy::fillCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color)
 {
   drawFastVLine(x0, y0-r, 2*r+1, color);
   fillCircleHelper(x0, y0, r, 3, 0, color);
 }
 
 void Arduboy::fillCircleHelper
-(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, int16_t delta,
+(int16_t x0, int16_t y0, uint8_t r, uint8_t cornername, int16_t delta,
  uint8_t color)
 {
   // used to do circles and roundrects!
@@ -341,7 +341,7 @@ void Arduboy::drawLine
 }
 
 void Arduboy::drawRect
-(int16_t x, int16_t y, int16_t w, int16_t h, uint8_t color)
+(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
 {
   drawFastHLine(x, y, w, color);
   drawFastHLine(x, y+h-1, w, color);
@@ -350,7 +350,7 @@ void Arduboy::drawRect
 }
 
 void Arduboy::drawFastVLine
-(int16_t x, int16_t y, int16_t h, uint8_t color)
+(int16_t x, int16_t y, uint8_t h, uint8_t color)
 {
   int end = y+h;
   for (int a = max(0,y); a < min(end,HEIGHT); a++)
@@ -360,7 +360,7 @@ void Arduboy::drawFastVLine
 }
 
 void Arduboy::drawFastHLine
-(int16_t x, int16_t y, int16_t w, uint8_t color)
+(int16_t x, int16_t y, uint8_t w, uint8_t color)
 {
   int end = x+w;
   for (int a = max(0,x); a < min(end,WIDTH); a++)
@@ -370,7 +370,7 @@ void Arduboy::drawFastHLine
 }
 
 void Arduboy::fillRect
-(int16_t x, int16_t y, int16_t w, int16_t h, uint8_t color)
+(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
 {
   // stupidest version - update in subclasses if desired!
   for (int16_t i=x; i<x+w; i++)
@@ -385,7 +385,7 @@ void Arduboy::fillScreen(uint8_t color)
 }
 
 void Arduboy::drawRoundRect
-(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint8_t color)
+(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
 {
   // smarter version
   drawFastHLine(x+r, y, w-2*r, color); // Top
@@ -400,7 +400,7 @@ void Arduboy::drawRoundRect
 }
 
 void Arduboy::fillRoundRect
-(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint8_t color)
+(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
 {
   // smarter version
   fillRect(x+r, y, w-2*r, h, color);
@@ -522,7 +522,7 @@ void Arduboy::fillTriangle
 }
 
 void Arduboy::drawBitmap
-(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, 
+(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, 
  uint8_t color)
 {
   // no need to dar at all of we're offscreen
@@ -562,7 +562,7 @@ void Arduboy::drawBitmap
 
 
 void Arduboy::drawSlowXYBitmap
-(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint8_t color)
+(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
 {
   // no need to dar at all of we're offscreen
   if (x+w < 0 || x > WIDTH-1 || y+h < 0 || y > HEIGHT-1)

--- a/Arduboy.h
+++ b/Arduboy.h
@@ -69,16 +69,16 @@ public:
   /**
    * Draws a circle in white or black. X and Y are the center point of the circle.
    */
-  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color);
+  void drawCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color);
 
   /// Draws one or more "corners" of a circle.
-  void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint8_t color);
+  void drawCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t cornername, uint8_t color);
 
   /// Draws a filled-in circle.
-  void fillCircle(int16_t x0, int16_t y0, int16_t r, uint8_t color);
+  void fillCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color);
 
    /// Draws one or both vertical halves of a filled-in circle.
-  void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, int16_t delta, uint8_t color);
+  void fillCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t cornername, int16_t delta, uint8_t color);
 
   /// Draws a line between two points.
   /**
@@ -87,25 +87,25 @@ public:
   void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint8_t color);
 
   /// Draws a rectangle of a width and height.
-  void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint8_t color);
+  void drawRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color);
 
   /// Draws vertical line.
-  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint8_t color);
+  void drawFastVLine(int16_t x, int16_t y, uint8_t h, uint8_t color);
 
   /// Draws a horizontal line.
-  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint8_t color);
+  void drawFastHLine(int16_t x, int16_t y, uint8_t w, uint8_t color);
 
   /// Draws a filled-in rectangle.
-  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint8_t color);
+  void fillRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color);
 
   /// Fills the screen buffer with white or black.
   void fillScreen(uint8_t color);
 
   /// Draws a rectangle with rounded edges.
-  void drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint8_t color);
+  void drawRoundRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color);
 
   /// Draws a filled-in rectangle with rounded edges.
-  void fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t r, uint8_t color);
+  void fillRoundRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color);
 
    /// Draws the outline of a triangle.
   void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color);
@@ -114,7 +114,7 @@ public:
   void fillTriangle (int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color);
 
   /// Draws a bitmap from program memory to a specific X/Y
-  void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint8_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color);
 
   /// Draws images that are bit-oriented horizontally.
   /**
@@ -123,7 +123,7 @@ public:
    * allows them to be directly written to the screen. It is
    * recommended you use drawBitmap when possible.
    */
-  void drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint8_t color);
+  void drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color);
 
   /// Draws an ASCII character at a point.
   void drawChar(int16_t x, int16_t y, unsigned char c, uint8_t color, uint8_t bg, uint8_t size);


### PR DESCRIPTION
- 44 bytes saves for Ardubreakout example sketch
- if you're using images/shapes taller/wider than 255 you
  made need to rethinking what you are doing
