### PR TITLE
Change ArduboyAudio::save_on_off() to ArduboyAudio::saveOnOff()

### DIFF
--- a/audio.cpp
+++ b/audio.cpp
@@ -60,7 +60,7 @@ void ArduboyAudio::off()
   power_timer3_disable();
 }
 
-void ArduboyAudio::save_on_off()
+void ArduboyAudio::saveOnOff()
 {
   EEPROM.write(EEPROM_AUDIO_ON_OFF, audio_enabled);
 }

--- a/audio.h
+++ b/audio.h
@@ -19,7 +19,7 @@ public:
   void static begin();
   void static on();
   void static off();
-  void static save_on_off();
+  void static saveOnOff();
   bool static enabled();
 
 protected:


### PR DESCRIPTION
For compliance with the [Arduino Style Guide for Writing Libraries](https://www.arduino.cc/en/Reference/APIStyleGuide). "Use camel case function names, not underscore."
