### PR TITLE
Init speaker pins in boot()

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -13,6 +13,15 @@ const uint8_t PROGMEM pinBootProgram[] = {
   PIN_A_BUTTON, INPUT_PULLUP,
   PIN_B_BUTTON, INPUT_PULLUP,
 
+  // speaker
+#ifdef ARDUBOY_10
+  PIN_SPEAKER_1, OUTPUT,
+  PIN_SPEAKER_1, OUTPUT,
+#elif defined(AB_DEVKIT)
+  PIN_SPEAKER_1, INPUT,
+  PIN_SPEAKER_2, INPUT,
+#endif
+
   // OLED SPI
   DC, OUTPUT,
   CS, OUTPUT,


### PR DESCRIPTION
In case someone uses _boot()_ to use their own audio system, and so doesn't call _audio.begin()_.

As discussed in issue #108.
