### PR TITLE
Use a dedicated #define to adjust the CPU clock

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -284,9 +284,10 @@ protected:
     void static inline safeMode() __attribute__((always_inline));
 
     // internals
+    void static inline setCPUSpeed8MHz() __attribute__((always_inline));
+    void static inline setCPUSpeed4MHz() __attribute__((always_inline));
     void static inline bootOLED() __attribute__((always_inline));
     void static inline bootPins() __attribute__((always_inline));
-    void static inline bootCPUSpeed() __attribute__((always_inline));
     void static inline bootPowerSaving() __attribute__((always_inline));
 
 


### PR DESCRIPTION
As discussed [here](https://github.com/Arduboy/Arduboy/pull/101#issuecomment-187314617).

I moved the speed adjustment code from _boot()_ to the constructor. The sooner it gets done, the better. Ideally, it should be done immediately after the bootloader exits.

I added the capability of setting 4MHz, just because. It doesn't hurt anything.
