### PR TITLE
Use a dedicated #define to adjust the CPU clock (fixed)

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -284,9 +284,9 @@ protected:
     void static inline safeMode() __attribute__((always_inline));
 
     // internals
+    void static inline setCPUSpeed8MHz() __attribute__((always_inline));
     void static inline bootOLED() __attribute__((always_inline));
     void static inline bootPins() __attribute__((always_inline));
-    void static inline bootCPUSpeed() __attribute__((always_inline));
     void static inline bootPowerSaving() __attribute__((always_inline));
 
 


### PR DESCRIPTION
As per discussion it PR #111.

I've tested this as best as possible without a proper boards.txt (which I haven't had time to install and get working).

Regarding the [boards.txt](https://github.com/yyyc514/hardware_arduboy/blob/master/avr/boards.txt) file that @yyyc514 designed to allow selecting this:
- As mention previously, all instances of _Mhz_, that will displayed to the user or are used as comments in the file, should be changed to _MHz_. The _H_ should be capitalized.
- I think using `Speed`, as a menu item to select the operating speed, is a bit ambiguous and could be confusing. Users could think it specifies the physical clock speed and assume that there must be an 8MHz version of the Arduboy out there, which you would select 8MHz for. I would suggest changing the menu item `Speed` to `Run Arduboy` and change the selection values to `at full speed, 16MHz` and `with speed reduced to 8MHz`.
