### PR TITLE
fix frame timing

### DIFF
--- a/UPGRADING_12.md
+++ b/UPGRADING_12.md
@@ -1,0 +1,35 @@
+Upgrading to 1.2
+================
+
+Version 1.2 of the library includes a few large breaking changes.
+
+### AbPrinter
+
+Arduboy no longer subclasses `Print` so no more printing/text operations.  Use the new AbPrinter class instead.
+
+    // Before
+    Arduboy arduboy;
+    // ...
+    arduboy.print("Hello");
+    
+    // After
+    Arduboy arduboy;
+    // ...
+    AbPrinter text(arduboy);
+    text.print("Hello");
+
+
+### ArduboyTunes
+
+ArduboyTunes is no longer part of the library.  If you want it you can still use it.  You can find it at https://github.com/Arduboy/ArduboyPlayTune.  Look at the Tunes examples for how to use the library now that it's been split into it's own library.
+
+There are also other great choices such as [Squawk](https://github.com/stg/Squawk), etc.  Or you can now use the standard Arduino Tone library without any issues.
+
+We still recommend you use `audio.on()`, `audio.off()`, and `audio.enabled()` to manage the actual state of the audio system.
+
+
+### Frame rate
+
+The [previous frame rate logic was buggy](https://github.com/Arduboy/Arduboy/pull/115) and would cause your game to run too slow.  
+
+After upgrading your game could possibly run 50-100% faster than before.  You'll need to playtest and make sure you adjust your game timings for the new accurate framerate logic (or set a slower framerate).


### PR DESCRIPTION
previosly timing was calculating the next frame based on now + duration
when the correct timing should have been last_frame + duration.

This would have the effect of slowing the game down the higher your CPU
usage.  A 0% CPU usage game would  play at the request frame rate,
but a 100% CPU usage game would play at only half the requested frame rate.

(RR is render time below)

```
Timing with the bug:
60FPs requested, 35FPs actual, 3 frames, 87ms.
|         29ms         |         29ms         |         29ms         |
| RR 12ms + 17ms sleep | RR 12ms + 17ms sleep | RR 12ms + 17ms sleep |

Timing after the fix:
60FPs, 60FPs actual, 3 frames, 51ms.
|       17ms      |       17ms      |       17ms      |
| RR 12ms + sleep | RR 12ms + sleep | RR 12ms + sleep |
```

After this fix you may need to change your games timing mechanics or
adjust your frame rate (to slow things back down). Your game will run
faster after this fix, even if you were using "100% CPU" before.
