### PR TITLE
Fix Arduino v1.0.5 compatibility issue with deprecated attribute

### DIFF
--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -63,7 +63,7 @@ public:
    */
   // void boot(); // defined in core.cpp
 
-  void start() __attribute__ ((deprecated("use begin() instead")));
+  void start() __attribute__ ((warning("use begin() instead")));
 
   /// Scrolls in the Arduboy logo
   void bootLogo();
@@ -79,7 +79,7 @@ public:
 
   /// Clears display.
   void clear();
-  void clearDisplay() __attribute__ ((deprecated("use clear() instead")));
+  void clearDisplay() __attribute__ ((warning("use clear() instead")));
 
   /// Copies the contents of the screen buffer to the screen.
   /**


### PR DESCRIPTION
Hello,

I am Pavlos from [codebender](https://codebender.cc). We're currently testing your updated library in order to add it in our supported libraries list. The testing showed that there are some issues with the current `Arduboy.h` header.  It looks like the Arduino's 1.0.5 compiler (that codebender is currently compatible with) chokes on `__atributte__((deprecated("message")))`. It supports just `__atributte__((deprecated))` without a message or `__atributte__((warning("message")))` instead. We thought removing the message is better for semantics but if you insist on the message then we could take the `warning` approach.

Please let me know if you any questions.

Thanks,
Pavlos
