### PR TITLE
Change EEPROM write() to update()

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -20,7 +20,7 @@ void ArduboyAudio::off()
 
 void ArduboyAudio::saveOnOff()
 {
-  EEPROM.write(EEPROM_AUDIO_ON_OFF, audio_enabled);
+  EEPROM.update(EEPROM_AUDIO_ON_OFF, audio_enabled);
 }
 
 void ArduboyAudio::begin()


### PR DESCRIPTION
Using [_EEPROM.update()_](https://www.arduino.cc/en/Reference/EEPROMUpdate) instead of [_EEPROM.write()_](https://www.arduino.cc/en/Reference/EEPROMWrite) will work exactly the same, except the actual write to EEPROM won't take place if the value already in EEPROM is the same as what's being written. This will prevent impacting the limited number of EEPROM write cycles if there's no need to.
