### PR TITLE
Combine function __attribute__ statments

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,6 +14,7 @@ Arduboy	KEYWORD1
 
 allPixelsOn	KEYWORD2
 blank	KEYWORD2
+buttonsState	KEYWORD2
 clear	KEYWORD2
 cpuLoad	KEYWORD2
 display	KEYWORD2
@@ -38,7 +39,6 @@ fillTriangle	KEYWORD2
 flipVertical	KEYWORD2
 flipHorizontal	KEYWORD2
 getBuffer	KEYWORD2
-getInput	KEYWORD2
 idle	KEYWORD2
 initRandomSeed	KEYWORD2
 invert	KEYWORD2

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -69,7 +69,7 @@ public:
    */
   // void boot(); // defined in core.cpp
 
-  void start() __attribute__((deprecated)) __attribute__ ((warning("use begin() instead")));
+  void start() __attribute__((deprecated, warning("use begin() instead")));
 
   /// Scrolls in the Arduboy logo
   void bootLogo();
@@ -85,7 +85,7 @@ public:
 
   /// Clears display.
   void clear();
-  void clearDisplay() __attribute__((deprecated)) __attribute__ ((warning("use clear() instead")));
+  void clearDisplay() __attribute__((deprecated, warning("use clear() instead")));
 
   /// Copies the contents of the screen buffer to the screen.
   /**

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -182,7 +182,7 @@ public:
      * LEFT_BUTTON, A_BUTTON, UP_BUTTON, etc.
      */
 
-    uint8_t static getInput(); __attribute__((deprecated)) __attribute__ ((warning("use buttonsState() instead")));
+    uint8_t static getInput() __attribute__((deprecated, warning("use buttonsState() instead")));
     uint8_t static buttonsState();
 
     // paints 8 pixels (vertically) from a single byte


### PR DESCRIPTION
Also deleted _getInput_ keyword and added _buttonsState_ keyword.

Note that the `__attribute__` declaration(s) for _getInput()_ have never worked. There was a colon left at the end of _getInput()_, so the `__atribute__` statement wasn't associated with anything and did nothing. I've corrected this.
