### PR TITLE
Fix bug in buttons sketch created when the AbPrinter class was added

### DIFF
--- a/examples/Buttons/Buttons.ino
+++ b/examples/Buttons/Buttons.ino
@@ -31,7 +31,7 @@ byte y;
 
 // To get the number of characters, we subtract 1 from the length of
 // the array because there will be a NULL terminator at the end.
-#define NUM_CHARS (sizeof(text) - 1)
+#define NUM_CHARS (sizeof(title) - 1)
 
 // This is the highest value that x can be without the end of the text
 // going farther than the right side of the screen. We add one because


### PR DESCRIPTION
Originally, the message printed on the screen was named _text_. When the AbPrinter class was added, the instance was named _text_ and the message was renamed to _title_. In the line that determined the size of the message it wasn't changed to _title_.
