### PR TITLE
Fix setting CPU clock to 8MHz

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -93,10 +93,10 @@ ArduboyCore::ArduboyCore() {}
 
 void ArduboyCore::boot()
 {
-#ifdef ARDUBOY_SET_CPU_8MHZ
-// ARDUBOY_SET_CPU_8MHZ will be set by the IDE using boards.txt
+  #ifdef ARDUBOY_SET_CPU_8MHZ
+  // ARDUBOY_SET_CPU_8MHZ will be set by the IDE using boards.txt
   setCPUSpeed8MHz();
-#endif
+  #endif
 
   SPI.begin();
   bootPins();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -283,9 +283,9 @@ protected:
     void static inline safeMode() __attribute__((always_inline));
 
     // internals
+    void static inline setCPUSpeed8MHz() __attribute__((always_inline));
     void static inline bootOLED() __attribute__((always_inline));
     void static inline bootPins() __attribute__((always_inline));
-    void static inline bootCPUSpeed() __attribute__((always_inline));
     void static inline bootPowerSaving() __attribute__((always_inline));
 
 


### PR DESCRIPTION
I'm not so sure we want to allow the possibility of changing the clock speed down to 8MHz, but the code currently in the library doesn't quite work properly. This pull request works properly, as far as I've tested it. The main discussion on this is in PR #112 (That PR is superseded by this one and can be ignored/closed). I have a _boards.txt_ file available, that would be required to select 8MHz, if we want to go "all the way" with this feature.

I see some issues with allowing 8MHz operation, which may be reason to just remove the related code completely instead of applying this PR:
- The person compiling the sketch must be the one to decide to run it at 8MHz. The decision to do so would have to be made by trial and error or by the sketch's documentation indicating that it will work properly at the slower speed. There's no way for a sketch itself to force proper 8MHz operation.
- The selected speed has to be checked and possibly changed each time a new sketch is compiled to make sure it's right. If the IDE is left at 8MHz from the previous sketch and then a new sketch is compiled/loaded that requires 16MHz, it will not run properly, possibly causing some "head scratching" or frustration.
- If a person sets for 8MHz but the sketch doesn't use a version of the library that supports it, there's a good chance that the USB port will not function properly after the sketch starts running, requiring the reset button to be pressed to upload a new sketch. This would affect sketches that use their own library, such as those by [Team a.r.g.](http://www.team-arg.org/) (unless they add the equivalent support).
- Even though the code fixes the USB corruption problem when the sketch starts, there's a possibility that a sketch, or a library it uses, could do some USB operations that corrupt the USB port later in the sketch, thus requiring the use of the reset button to recover.
- Probably the only reason to run at 8MHz is to reduce the power used, for longer battery life. No tests have been done to determine how much power would be saved.
- Just the fact of having a selection for 16MHz or 8MHz in the IDE may cause people to ask what it's for and how and when it should be set.

Because of the above, I think most people would probably just always compile for 16MHz, so I don't know how beneficial this feature would be, or whether the benefits outweigh the potential drawbacks.

If we decide it's better to just to remove the 8MHz selection code, I can create a pull request to do so (or maybe just another commit on this one, so the working 8MHz code is stored somewhere for possible future reference). We could also just apply this PR, so it works properly, but not actually make changes to _boards.txt_ to allow it's use.
