### PR TITLE
Keep V1.1 nextFrame() and add newFrame(). Put beginNoLogo() back in

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -51,7 +51,7 @@ height	KEYWORD2
 idle	KEYWORD2
 initRandomSeed	KEYWORD2
 invert	KEYWORD2
-nextFrame	KEYWORD2
+newFrame	KEYWORD2
 notPressed	KEYWORD2
 off	KEYWORD2
 on	KEYWORD2

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -8,7 +8,7 @@
 #include "ab_logo.c"
 #include "glcdfont.c"
 
-uint8_t ArduboyBase::sBuffer[(HEIGHT * WIDTH) / 8];
+uint8_t ArduboyBase::sBuffer[];
 
 ArduboyBase::ArduboyBase()
 {

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -119,6 +119,20 @@ void ArduboyBase::bootLogo()
   digitalWrite(BLUE_LED, RGB_OFF);
 }
 
+// This function is deprecated.
+// It is retained for backwards compatibility.
+// New code should use boot() as a base.
+void ArduboyBase::beginNoLogo()
+{
+  boot();       // raw hardware
+  blank();      // blank the display
+
+  // start the flashlight
+  flashlight(UP_BUTTON, DOWN_BUTTON);
+
+  audio.begin();   // start the audio
+}
+
 /* Frame management */
 
 void ArduboyBase::setFrameRate(uint8_t rate)

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -461,10 +461,23 @@ public:
   void setFrameRate(uint8_t rate);
 
   /**
-   * Returns 'true' if the system is ready to draw the next frame.
-   * \return Returns true if the Arduboy is ready to draw the next frame.
+   * Returns 'true' if the desired time to draw a new frame has elapsed.
+   * The time period is set using setFrameRate().
+   * \return Returns true if it's time to draw a new frame.
    */
-  bool nextFrame();
+  bool newFrame();
+
+  /**
+   * Returns 'true' if it's time to draw the next frame.
+   * \deprecated This functon has a bug which can result in the frame rate
+   * being slower than what is set, and vary depending on CPU load. It has been
+   * retained so that older sketches using it will continue to run at the same
+   * speed. New sketches should use newFrame(). It is recommended that sketches
+   * already using nextFrame() be modified to use newFrame() if possible.
+   * \return Returns true if it's time to draw the next frame.
+   */
+  bool nextFrame()
+      __attribute__((deprecated, warning("consider using newFrame() instead")));
 
   /**
    * Returns true if the current frame number is evenly divisible by the

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -144,9 +144,19 @@ public:
    */
   void flashlight(uint8_t on_button, uint8_t off_button);
 
-  /// Deprecitated function to clear an Arduboy display. Use clear() instead.
+  /// Deprecated function to clear an Arduboy display. Use clear() instead.
   void clearDisplay() 
       __attribute__((deprecated, warning("use clear() instead")));
+
+  /**
+   * Do the same as begin() except don't display the boot logo sequence or
+   * handle system control buttons.
+   * \deprecated This function has been retained for backwards compatibility.
+   * It should not be used for new development. Instead, use boot() and
+   * optionally add functions back in that begin() performs.
+   */
+  void beginNoLogo()
+      __attribute__((deprecated, warning("use boot() plus optional extra functions instead")));
 
   /**
    * Copies the contents of the screen buffer to the screen.

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -99,7 +99,7 @@ public:
   void begin();
 
   /// Depreciated function. Use begin instead.
-  void start() __attribute__((deprecated, warning("use begin() instead")));
+  void start() __attribute__((deprecated("use begin() instead")));
 
   /**
    * Scrolls in the Arduboy logo
@@ -145,8 +145,7 @@ public:
   void flashlight(uint8_t on_button, uint8_t off_button);
 
   /// Deprecated function to clear an Arduboy display. Use clear() instead.
-  void clearDisplay() 
-      __attribute__((deprecated, warning("use clear() instead")));
+  void clearDisplay() __attribute__((deprecated("use clear() instead")));
 
   /**
    * Do the same as begin() except don't display the boot logo sequence or
@@ -156,7 +155,7 @@ public:
    * optionally add functions back in that begin() performs.
    */
   void beginNoLogo()
-      __attribute__((deprecated, warning("use boot() plus optional extra functions instead")));
+      __attribute__((deprecated("use boot() plus optional extra functions instead")));
 
   /**
    * Copies the contents of the screen buffer to the screen.
@@ -487,7 +486,7 @@ public:
    * \return Returns true if it's time to draw the next frame.
    */
   bool nextFrame()
-      __attribute__((deprecated, warning("consider using newFrame() instead")));
+      __attribute__((deprecated("consider using newFrame() instead")));
 
   /**
    * Returns true if the current frame number is evenly divisible by the

--- a/src/ArduboyCore.cpp
+++ b/src/ArduboyCore.cpp
@@ -350,3 +350,8 @@ uint8_t ArduboyCore::buttonsState()
 
   return buttons;
 }
+
+uint8_t ArduboyCore::getInput() // deprecated
+{
+  return buttonsState();
+}

--- a/src/ArduboyCore.h
+++ b/src/ArduboyCore.h
@@ -211,7 +211,7 @@ public:
 
   /// Deprecated. Use buttonsState() instead.
   uint8_t static getInput()
-      __attribute__((deprecated, warning("use buttonsState() instead")));
+      __attribute__((deprecated("use buttonsState() instead")));
 
   /**
    * Paints 8 pixels (vertically) from a single byte. 1 is on, 0 is off.

--- a/src/ArduboyCore.h
+++ b/src/ArduboyCore.h
@@ -209,6 +209,10 @@ public:
    */
   uint8_t static buttonsState();
 
+  /// Deprecated. Use buttonsState() instead.
+  uint8_t static getInput()
+      __attribute__((deprecated, warning("use buttonsState() instead")));
+
   /**
    * Paints 8 pixels (vertically) from a single byte. 1 is on, 0 is off.
    * \param pixels uint8_t


### PR DESCRIPTION
These changes are to help maintain backwards compatibility with the V1.1 API
- Leave the timing bug in _nextFrame()_ but deprecate the function. This way, existing sketches using _nextFrame()_ will continue to run at the same speed. The version of _nextFrame()_ with the bug fix is added in and named _newFrame()_. All new development should use _newFrame()_. Existing sketches can be modified to use it if desired.
- Put an equivalent version of the V1.1 _beginNoLogo()_ function back in. This will allow existing sketches using it to compile. New development should use _boot()_ plus, optionally, additional functions from _begin()_.
