### PR TITLE
Remove parameters from flashlight()

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -51,7 +51,7 @@ height	KEYWORD2
 idle	KEYWORD2
 initRandomSeed	KEYWORD2
 invert	KEYWORD2
-nextFrame	KEYWORD2
+newFrame	KEYWORD2
 notPressed	KEYWORD2
 off	KEYWORD2
 on	KEYWORD2

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -33,38 +33,28 @@ void ArduboyBase::begin()
 {
   boot();       // raw hardware
   blank();      // blank the display
-
-  // start the flashlight
-  flashlight(UP_BUTTON, DOWN_BUTTON);
-
+  flashlight(); // start the flashlight if the UP button is held
   systemButtons(); // check for the presence of any held system buttons
   bootLogo();      // display the boot logo
   audio.begin();   // start the audio
 }
 
-void ArduboyBase::flashlight(uint8_t on_button, uint8_t off_button)
+void ArduboyBase::flashlight()
 {
-  if (pressed(on_button)) flashlight(off_button);
-}
+  if(!pressed(UP_BUTTON))
+    return;
 
-void ArduboyBase::flashlight(uint8_t off_button)
-{
   // turn all pixels on
   sendLCDCommand(OLED_ALL_PIXELS_ON);
   // turn red, green and blue LEDS on for white light
   digitalWriteRGB(RGB_ON, RGB_ON, RGB_ON);
 
   // until the down button is pressed, stay in flashlight mode.
-  while (!pressed(off_button))
+  while (!pressed(DOWN_BUTTON))
     idle();
 
   digitalWriteRGB(RGB_OFF, RGB_OFF, RGB_OFF);
   sendLCDCommand(OLED_PIXELS_FROM_RAM);
-}
-
-void ArduboyBase::flashlight()
-{
-  flashlight(UP_BUTTON, DOWN_BUTTON);
 }
 
 void ArduboyBase::systemButtons()
@@ -126,10 +116,7 @@ void ArduboyBase::beginNoLogo()
 {
   boot();       // raw hardware
   blank();      // blank the display
-
-  // start the flashlight
-  flashlight(UP_BUTTON, DOWN_BUTTON);
-
+  flashlight(); // start the flashlight if the UP button is held
   audio.begin();   // start the audio
 }
 

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -8,7 +8,7 @@
 #include "ab_logo.c"
 #include "glcdfont.c"
 
-uint8_t ArduboyBase::sBuffer[(HEIGHT * WIDTH) / 8];
+uint8_t ArduboyBase::sBuffer[];
 
 ArduboyBase::ArduboyBase()
 {

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -119,6 +119,20 @@ void ArduboyBase::bootLogo()
   digitalWrite(BLUE_LED, RGB_OFF);
 }
 
+// This function is deprecated.
+// It is retained for backwards compatibility.
+// New code should use boot() as a base.
+void ArduboyBase::beginNoLogo()
+{
+  boot();       // raw hardware
+  blank();      // blank the display
+
+  // start the flashlight
+  flashlight(UP_BUTTON, DOWN_BUTTON);
+
+  audio.begin();   // start the audio
+}
+
 /* Frame management */
 
 void ArduboyBase::setFrameRate(uint8_t rate)

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -66,6 +66,8 @@ void ArduboyBase::systemButtons()
     sysCtrlSound(DOWN_BUTTON + B_BUTTON, RED_LED, 0);
     delay(200);
   }
+
+  digitalWrite(BLUE_LED, RGB_OFF);
 }
 
 void ArduboyBase::sysCtrlSound(uint8_t buttons, uint8_t led, uint8_t eeVal)
@@ -90,10 +92,13 @@ void ArduboyBase::bootLogo()
   for (int8_t y = -18; y <= 24; y++)
   {
     if (y == -4)
-      digitalWriteRGB(RGB_OFF, RGB_ON, RGB_OFF);
-
-    if (y == -4)
-      digitalWriteRGB(RGB_OFF, RGB_ON, RGB_OFF);
+    {
+      digitalWriteRGB(RGB_OFF, RGB_ON, RGB_OFF); // green LED on
+    }
+    else if (y == 24)
+    {
+      digitalWriteRGB(RGB_OFF, RGB_OFF, RGB_ON); // blue LED on
+    }
 
     clear();
     drawBitmap(20, y, arduboy_logo, 88, 16, WHITE);

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -102,51 +102,31 @@ public:
   void start() __attribute__((deprecated, warning("use begin() instead")));
 
   /**
+   * Flashlight mode handler.
+   * \details
+   * Flashlight mode is a boot up function that checks if the UP button is
+   * being held and, if so, turns the RGB LED on full white and lights all the
+   * screen pixels. When the DOWN button is pressed, flashlight mode exits and
+   * the sketch continues.
+   */
+  void flashlight();
+
+  /**
+   * Provide system control during the boot sequence.
+   * \details
+   * An opportunity to provide a level of system control is given during the
+   * boot sequence. Control is given to systemSetup() if specified buttons 
+   * are held during an Arduboy's startup.
+   */
+  void systemButtons();
+
+  /**
    * Scrolls in the Arduboy logo
    * \details
    * Scrolls the logo stored in memory for Arduboy down the screen. LEDs will
    * flash during the boot sequence.
    */
   void bootLogo();
-
-  /**
-   * Clears display.
-   * \details
-   * Clear the image buffer for the controlled Arduboy.
-   */
-  void clear();
-
-  /**
-   * Provide flashlight mode, providing a default on and off button..
-   * \details
-   * The flashlight mode will places the programmble LED on an Arduboy to white
-   * and turn all of the pixels on the screen on. The default buttons provided
-   * to check before turning on the flashlight are UP_BUTTON and DOWN_BUTTON
-   * for on and off, respectivly.
-   */
-  void flashlight();
-
-  /**
-   * Flashlight mode, provide off button only.
-   * \param off_button The button to turn off flashlight mode.
-   */
-  void flashlight(uint8_t off_button);
-
-  /**
-   * Flashlight mode, provide on and off button.
-   * \param on_button uint8_t button to check before turning on flashlight.
-   * \param off_button uint8_t button to press to turn off flashlight.
-   * \details
-   * Hold a key when booting to enable, press a provided key to exit;
-   * or simply turn off your Arduboy.  Your sketches can also
-   * call this at any time.  It goes into a tight loop until the
-   * off_button is pressed.
-   */
-  void flashlight(uint8_t on_button, uint8_t off_button);
-
-  /// Deprecated function to clear an Arduboy display. Use clear() instead.
-  void clearDisplay() 
-      __attribute__((deprecated, warning("use clear() instead")));
 
   /**
    * Do the same as begin() except don't display the boot logo sequence or
@@ -157,6 +137,17 @@ public:
    */
   void beginNoLogo()
       __attribute__((deprecated, warning("use boot() plus optional extra functions instead")));
+
+  /**
+   * Clears display.
+   * \details
+   * Clear the image buffer for the controlled Arduboy.
+   */
+  void clear();
+
+  /// Deprecated function to clear an Arduboy display. Use clear() instead.
+  void clearDisplay() 
+      __attribute__((deprecated, warning("use clear() instead")));
 
   /**
    * Copies the contents of the screen buffer to the screen.
@@ -516,15 +507,6 @@ public:
    * \return Return ADC as an unsigned 16 bit integer.
    */
   uint16_t rawADC(uint8_t adc_bits);
-
-  /**
-   * Provide system control during the boot sequence.
-   * \details
-   * An opportunity to provide a level of system control is given during the
-   * boot sequence. Control is given to systemSetup() if specified buttons 
-   * are held during an Arduboy's startup.
-   */
-  void systemButtons();
 
 protected:
 

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -461,10 +461,23 @@ public:
   void setFrameRate(uint8_t rate);
 
   /**
-   * Returns 'true' if the system is ready to draw the next frame.
-   * \return Returns true if the Arduboy is ready to draw the next frame.
+   * Returns 'true' if the desired time to draw a new frame has elapsed.
+   * The time period is set using setFrameRate().
+   * \return Returns true if it's time to draw a new frame.
    */
-  bool nextFrame();
+  bool newFrame();
+
+  /**
+   * Returns 'true' if it's time to draw the next frame.
+   * \deprecated This functon has a bug which can result in the frame rate
+   * being slower than what is set, and vary depending on CPU load. It has been
+   * retained so that older sketches using it will continue to run at the same
+   * speed. New sketches should use newFrame(). It is recommended that sketches
+   * already using nextFrame() be modified to use newFrame() if possible.
+   * \return Returns true if it's time to draw the next frame.
+   */
+  bool nextFrame()
+      __attribute__((deprecated, warning("consider using newFrame() instead")));
 
   /**
    * Returns true if the current frame number is evenly divisible by the

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -144,9 +144,19 @@ public:
    */
   void flashlight(uint8_t on_button, uint8_t off_button);
 
-  /// Deprecitated function to clear an Arduboy display. Use clear() instead.
+  /// Deprecated function to clear an Arduboy display. Use clear() instead.
   void clearDisplay() 
       __attribute__((deprecated, warning("use clear() instead")));
+
+  /**
+   * Do the same as begin() except don't display the boot logo sequence or
+   * handle system control buttons.
+   * \deprecated This function has been retained for backwards compatibility.
+   * It should not be used for new development. Instead, use boot() and
+   * optionally add functions back in that begin() performs.
+   */
+  void beginNoLogo()
+      __attribute__((deprecated, warning("use boot() plus optional extra functions instead")));
 
   /**
    * Copies the contents of the screen buffer to the screen.


### PR DESCRIPTION
Allowing the _flashlight()_ buttons to be specified takes more code space. The buttons should be standardised. It's not likely the _flashlight()_ function will be called in the middle of a sketch after boot up.

Other changes:
- includes PR #145 
- Reorder some function calls for readability.
- Fixed copy/paste errors in _systemButtons()_ and _bootLogo()_ which caused them not to work properly.
