### PR TITLE
Put getInput() back in. Remove warning attributes

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library is for content creation on the Arduboy, a portable gaming
 category=Other
 url=https://github.com/arduboy/arduboy
 architectures=avr
+includes=Arduboy.h

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -99,7 +99,7 @@ public:
   void begin();
 
   /// Depreciated function. Use begin instead.
-  void start() __attribute__((deprecated, warning("use begin() instead")));
+  void start() __attribute__((deprecated("use begin() instead")));
 
   /**
    * Flashlight mode handler.
@@ -136,7 +136,7 @@ public:
    * optionally add functions back in that begin() performs.
    */
   void beginNoLogo()
-      __attribute__((deprecated, warning("use boot() plus optional extra functions instead")));
+      __attribute__((deprecated("use boot() plus optional extra functions instead")));
 
   /**
    * Clears display.
@@ -146,8 +146,7 @@ public:
   void clear();
 
   /// Deprecated function to clear an Arduboy display. Use clear() instead.
-  void clearDisplay() 
-      __attribute__((deprecated, warning("use clear() instead")));
+  void clearDisplay() __attribute__((deprecated("use clear() instead")));
 
   /**
    * Copies the contents of the screen buffer to the screen.
@@ -478,7 +477,7 @@ public:
    * \return Returns true if it's time to draw the next frame.
    */
   bool nextFrame()
-      __attribute__((deprecated, warning("consider using newFrame() instead")));
+      __attribute__((deprecated("consider using newFrame() instead")));
 
   /**
    * Returns true if the current frame number is evenly divisible by the

--- a/src/ArduboyCore.cpp
+++ b/src/ArduboyCore.cpp
@@ -350,3 +350,8 @@ uint8_t ArduboyCore::buttonsState()
 
   return buttons;
 }
+
+uint8_t ArduboyCore::getInput() // deprecated
+{
+  return buttonsState();
+}

--- a/src/ArduboyCore.h
+++ b/src/ArduboyCore.h
@@ -211,7 +211,7 @@ public:
 
   /// Deprecated. Use buttonsState() instead.
   uint8_t static getInput()
-      __attribute__((deprecated, warning("use buttonsState() instead")));
+      __attribute__((deprecated("use buttonsState() instead")));
 
   /**
    * Paints 8 pixels (vertically) from a single byte. 1 is on, 0 is off.

--- a/src/ArduboyCore.h
+++ b/src/ArduboyCore.h
@@ -209,6 +209,10 @@ public:
    */
   uint8_t static buttonsState();
 
+  /// Deprecated. Use buttonsState() instead.
+  uint8_t static getInput()
+      __attribute__((deprecated, warning("use buttonsState() instead")));
+
   /**
    * Paints 8 pixels (vertically) from a single byte. 1 is on, 0 is off.
    * \param pixels uint8_t


### PR DESCRIPTION
This is a merge-able version of the last two commits of PR #145: 

---

Added a commit to put the deprecated function _getInput()_ back in. We're trying to make this as backwards compatible to V1.1 as possible.

I think this function was unintentionally removed instead of leaving it in but letting it remain deprecated.

---

According to a comment made by @dastergon in PR #123 the compiler used by Arduino V1.0.5 doesn't like a _deprecated_ attribute with a message, which causes problems with _codebender_. However, I've tried it with V1.0.5 and found that _deprecated_ attributes with a message work properly.

There's no need to use a _warning_ attribute to provide a message, so a commit has been added to this PR to remove them.

Besides, if this is a problem with _codebender_ then it can be addressed in the _ArduboyClasssic_ library that _codebender_ uses.
