### PR TITLE
Fix paintScreen() for IDE 1.6.10

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,14 @@
+{
+    "name": "Arduboy",
+    "keywords": "arduboy, game",
+    "description": "This library is for content creation on the Arduboy, a portable gaming platform",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/Arduboy/Arduboy.git"
+    },
+    "version": "1.1.1",
+    "exclude": "extras",
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduboy
-version=1.1.0
+version=1.1.1
 author=Chris J. Martinez, Kevin Bates, Josh Goebel, Scott Allen, Ross O. Shoger
 maintainer=Ross O. Shoger ros@arduboy.com
 sentence=The Arduboy core library.
@@ -7,3 +7,4 @@ paragraph=This library is for content creation on the Arduboy, a portable gaming
 category=Other
 url=https://github.com/arduboy/arduboy
 architectures=avr
+includes=Arduboy.h

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -6,6 +6,14 @@
 #include <Print.h>
 #include <limits.h>
 
+/// Library version.
+/**
+ * A version number, 'x.y.z', is stored in the form xxyyzz,
+ * where ((x * 10000) + (y * 100) + (z)),
+ * resulting in 'xxxyyzz', with no leading zeros.
+ */
+#define ARDUBOY_LIB_VER 10101 // 1.1.1
+
 // EEPROM settings
 #define EEPROM_VERSION 0
 #define EEPROM_BRIGHTNESS 1


### PR DESCRIPTION
Arduino IDE 1.6.10 uses a new version of the compiler toolchain. The compiler now generates more efficient code so that the instruction padding in function _paintScreen()_, used to create a delay so a byte can be shifted out over SPI, is no longer sufficient.

The problem could be solved by adding more pad instructions, but this doesn't eliminate the possibility that the same thing won't occur in the future.

This PR fixes the problem by waiting for the _SPIF_ flag to indicate that the byte has been sent and the SPI controller is ready for a new one, instead of blindly using a delay to allow time for the byte to be sent.

This technique takes a bit longer to update the display. Previously the total time was 1.16 ms and now it's 1.42 ms (which is still shorter than using _SPI.transfer()_ for each byte, which takes 2.58 ms). 

Although it appears to be a significant increase in time, overall it shouldn't have too much of an impact. A sketch that used 100% of the CPU time to render frames at 60 fps will now still run at 59 fps.
