### PR TITLE
Fix paintScreen for IDE 1.6.10 and add combo display/clear functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,7 @@ clear	KEYWORD2
 cpuLoad	KEYWORD2
 digitalWriteRGB	KEYWORD2
 display	KEYWORD2
+displayAndClear	KEYWORD2
 drawBitmap	KEYWORD2
 drawChar	KEYWORD2
 drawCircle	KEYWORD2
@@ -57,6 +58,7 @@ off	KEYWORD2
 on	KEYWORD2
 paint8Pixels	KEYWORD2
 paintScreen	KEYWORD2
+paintScreenAndClearImage	KEYWORD2
 pressed	KEYWORD2
 saveOnOff	KEYWORD2
 setCursor	KEYWORD2

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -716,17 +716,17 @@ void ArduboyBase::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
           {
             if (color == WHITE)
             {
-              this->sBuffer[ (bRow*WIDTH) + x + iCol ] |=
+              sBuffer[ (bRow*WIDTH) + x + iCol ] |=
                 pgm_read_byte(bitmap + (a * w) + iCol) << yOffset;
             }
             else if (color == BLACK)
             {
-              this->sBuffer[ (bRow*WIDTH) + x + iCol ] &=
+              sBuffer[ (bRow*WIDTH) + x + iCol ] &=
                 ~(pgm_read_byte(bitmap + (a * w) + iCol) << yOffset);
             }
             else
             {
-              this->sBuffer[ (bRow*WIDTH) + x + iCol ] ^=
+              sBuffer[ (bRow*WIDTH) + x + iCol ] ^=
                 pgm_read_byte(bitmap + (a * w) + iCol) << yOffset;
             }
           }
@@ -734,17 +734,17 @@ void ArduboyBase::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
           {
             if (color == WHITE) 
             {
-              this->sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] |= 
+              sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] |=
                 pgm_read_byte(bitmap + (a * w) + iCol) >> (8 - yOffset);
             }
             else if (color == BLACK) 
             {
-              this->sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] &=
+              sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] &=
                 ~(pgm_read_byte(bitmap + (a * w) + iCol) >> (8 - yOffset));
             }
             else
             {
-              this->sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] ^=
+              sBuffer[ ((bRow+1)*WIDTH) + x + iCol ] ^=
                 pgm_read_byte(bitmap + (a * w) + iCol) >> (8 - yOffset);
             }
           }

--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -813,7 +813,12 @@ void ArduboyBase::drawChar
 void ArduboyBase::display()
 {
   // copy data to draw to buffer
-  this->paintScreen(sBuffer);
+  paintScreen(sBuffer);
+}
+
+void ArduboyBase::displayAndClear()
+{
+  paintScreenAndClearImage(sBuffer);
 }
 
 uint8_t* ArduboyBase::getBuffer()

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -315,9 +315,9 @@ public:
   /**
    * Fills the screen buffer with white or black.
    * \fn fillScreen
-   * \param color Optional, default = WHITE
+   * \param color Optional, default = BLACK
    */
-  void fillScreen(uint8_t color = WHITE);
+  void fillScreen(uint8_t color = BLACK);
 
   /**
    * Draws a rectangle with rounded edges.

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -159,6 +159,16 @@ public:
    */
   void display();
 
+ /**
+   * Perform the equivalent of display() followed by clear().
+   * \details
+   * The contents of the screen buffer are displayed and the screen buffer
+   * is cleared to zeros. The operations are performed in the same loop
+   * so will execute faster that if display() and then clear() were called
+   * separately.
+   */
+  void displayAndClear();
+
   /**
    * Managed draw function for an Arduboy.
    * \todo Thoroughly test this method for handling draws to the screen.

--- a/src/ArduboyCore.cpp
+++ b/src/ArduboyCore.cpp
@@ -244,20 +244,26 @@ void ArduboyCore::paintScreen(const uint8_t *image)
 // will be used by any buffer based subclass
 void ArduboyCore::paintScreen(uint8_t image[])
 {
-  for (int i = 0; i < (HEIGHT * WIDTH) / 8; i++)
-  {
-    // SPI.transfer(image[i]);
+  uint8_t c;
+  int i = 0;
 
-    // we need to burn 18 cycles between sets of SPDR
-    // 4 clock cycles
-    SPDR = image[i];
-    // 7 clock cycles
-    asm volatile(
-      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
-      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
-      "mul __zero_reg__, __zero_reg__ \n" // 2 cycles
-      );
+  SPDR = image[i++]; // set the first SPI data byte to get things started
+
+  // the code to iterate the loop and get the next byte from the buffer is
+  // executed while the previous byte is being sent out by the SPI controller
+  while (i < (HEIGHT * WIDTH) / 8)
+  {
+    // get the next byte. It's put in a local variable so it can be sent as
+    // as soon as possible after the sending of the previous byte has completed
+    c = image[i++];
+
+    while (!(SPSR & _BV(SPIF))) { } // wait for the previous byte to be sent
+
+    // put the next byte in the SPI data register. The SPI controller will
+    // clock it out while the loop continues and gets the next byte ready
+    SPDR = c;
   }
+  while (!(SPSR & _BV(SPIF))) { } // wait for the last byte to be sent
 }
 
 void ArduboyCore::blank()

--- a/src/ArduboyCore.h
+++ b/src/ArduboyCore.h
@@ -265,6 +265,18 @@ public:
   void static paintScreen(uint8_t image[]);
 
   /**
+   * Paints an entire image directly to hardware (from RAM) and zeros
+   * the contents of the image
+   * \param image[]
+   * \see paintScreen()
+   * \details
+   * Performs the same function as paintScreen() but also clears the image
+   * buffer in the same loop. This is faster than displaying the image and
+   * then clearing it separately in another function.
+   */
+  void static paintScreenAndClearImage(uint8_t image[]);
+
+  /**
    * Paints a blank (black) screen to the screen
    */
   void static blank();


### PR DESCRIPTION
Main commits:
- Applied the _paintScreen()_ fix from V1.1.1 which fixes the screen corruption problem with Arduino IDE 1.6.10
- Added core function _paintScreenAndClearImage()_, used by new function _displayAndClear()_. Many sketches call _display()_ and then use _clear()_ before rendering the next frame. Providing a function to do both saves these sketches a function call. Mainly though, because the buffer bytes are cleared while waiting for them to shifted out to the display, it doesn't take any more time than just calling _display()_. You save the extra time that a separate _clear()_ call would take.
  This was proposed in issue #89, which could be closed if this PR is applied.

Minor commits:
- For function _fillScreen()_, changed the default value for the _color_ argument from WHITE to BLACK. I think clearing the screen buffer to black (all zeros) will likely be the most common use of _fillScreen()_. This won't affect any existing code since nothing is currently calling _fillScreen()_ with a default.
- Removed the unnecessary use of the _this->_ pointer in function _drawBitmap()_. It's not used anywhere else. The library coding style should be consistent.
