### PR TITLE
Fix: write() should return a value

### DIFF
--- a/src/Arduboy.cpp
+++ b/src/Arduboy.cpp
@@ -876,6 +876,7 @@ size_t Arduboy::write(uint8_t c)
       write('\n');
     }
   }
+  return 1;
 }
 
 void Arduboy::setCursor(int16_t x, int16_t y)


### PR DESCRIPTION
The _write()_ function is defined as:

`virtual size_t write(uint8_t);`

It should return the number of bytes written. It wasn't returning anything. It now returns 1, which is the proper value since it's always given a 1 byte parameter and, in our implementation, can never fail.
