### PR TITLE
Don't deprecate nextFrame(), remove newFrame()

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -51,7 +51,7 @@ height	KEYWORD2
 idle	KEYWORD2
 initRandomSeed	KEYWORD2
 invert	KEYWORD2
-newFrame	KEYWORD2
+nextFrame	KEYWORD2
 notPressed	KEYWORD2
 off	KEYWORD2
 on	KEYWORD2

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -590,7 +590,7 @@ public:
 
   /**
    * Sets the text background color.
-   * \param color Pass an unsigned byte to set as background color.
+   * \param bg Pass an unsigned byte to set as background color.
    */
   void setTextBackground(uint8_t bg);
 

--- a/src/Arduboy.h
+++ b/src/Arduboy.h
@@ -492,23 +492,11 @@ public:
   void setFrameRate(uint8_t rate);
 
   /**
-   * Returns 'true' if the desired time to draw a new frame has elapsed.
+   * Returns 'true' if the desired time to draw the next frame has elapsed.
    * The time period is set using setFrameRate().
-   * \return Returns true if it's time to draw a new frame.
-   */
-  bool newFrame();
-
-  /**
-   * Returns 'true' if it's time to draw the next frame.
-   * \deprecated This functon has a bug which can result in the frame rate
-   * being slower than what is set, and vary depending on CPU load. It has been
-   * retained so that older sketches using it will continue to run at the same
-   * speed. New sketches should use newFrame(). It is recommended that sketches
-   * already using nextFrame() be modified to use newFrame() if possible.
    * \return Returns true if it's time to draw the next frame.
    */
-  bool nextFrame()
-      __attribute__((deprecated("consider using newFrame() instead")));
+  bool nextFrame();
 
   /**
    * Returns true if the current frame number is evenly divisible by the
@@ -546,9 +534,6 @@ protected:
   /// The Arduboy screen buffer.
   static uint8_t sBuffer[(HEIGHT * WIDTH) / 8];
 
-  /// Framerate to update image buffer at.
-  uint8_t frameRate;
-
   /// Current count of frames.
   uint16_t frameCount;
 
@@ -556,10 +541,10 @@ protected:
   uint8_t eachFrameMillis;
 
   /// Time of the frame last started.
-  long lastFrameStart;
+  unsigned long lastFrameStart;
 
   /// Time to start next frame.
-  long nextFrameStart;
+  unsigned long nextFrameStart;
 
   /// Flag to enable or disable post render processes.
   bool post_render;

--- a/src/ArduboyCore.cpp
+++ b/src/ArduboyCore.cpp
@@ -175,7 +175,7 @@ void ArduboyCore::bootOLED()
   LCDCommandMode();
   // run our customized boot-up command sequence against the
   // OLED to initialize it properly for Arduboy
-  for (int8_t i = 0; i < sizeof(lcdBootProgram); i++)
+  for (uint8_t i = 0; i < sizeof(lcdBootProgram); i++)
     SPI.transfer(pgm_read_byte(lcdBootProgram + i));
 
   LCDDataMode();

--- a/src/glcdfont.c
+++ b/src/glcdfont.c
@@ -5,7 +5,7 @@
 #define FONT5X7_H
 
 // standard ascii 5x7 font
-const static uint8_t font[] PROGMEM =
+static const uint8_t font[] PROGMEM =
 {
     0x00, 0x00, 0x00, 0x00, 0x00,
     0x3E, 0x5B, 0x4F, 0x5B, 0x3E,


### PR DESCRIPTION
Note: We may wish to hold off on applying this PR until @yyyc514 (if he sees this) can comment on why he though there was a problem with _nextFrame()_ timing, as discussed and addressed in PR #115

After reviewing the code and testing the timings using an oscilloscope, it appears that the _nextFrame()_ function works as designed. On the other hand, _newFrame()_, which is supposedly the corrected version of _nextFrame()_, does not behave as expected.

_newFrame()_ has been removed. _nextFrame()_ is no longer marked as deprecated and has been refactored slightly.

I tested cases where frame render times were both less than and greater than the specified frame rate. I also verified that the _cpuLoad()_ function returns correct values.

This PR also contains a commit to address two compiler warnings that appear if the IDE _Compiler warnings_ preference is set to _All_.
